### PR TITLE
fix: add standalone A2A CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,26 @@ mkdir -p ~/.hermes/plugins
 git clone <repo-url> ~/.hermes/plugins/a2a
 ```
 
-Then restart Hermes and verify:
+Then restart Hermes and verify the plugin is visible:
 
 ```bash
 hermes plugins list
+```
+
+If your Hermes version supports top-level CLI commands from standalone plugins,
+you can use:
+
+```bash
 hermes a2a status
 hermes a2a card
+```
+
+For Hermes versions that do not yet discover standalone plugin CLI commands, use
+the plugin-owned console script instead:
+
+```bash
+uv run hermes-a2a status
+uv run hermes-a2a card
 ```
 
 ## Runtime surfaces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ sdk = ["a2a-sdk[http-server,sqlite]>=0.3.0"]
 [project.entry-points."hermes_agent.plugins"]
 a2a = "hermes_a2a"
 
+[project.scripts]
+hermes-a2a = "hermes_a2a.cli:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/hermes_a2a/cli.py
+++ b/src/hermes_a2a/cli.py
@@ -1,7 +1,14 @@
-"""CLI entrypoints for `hermes a2a ...`."""
+"""CLI entrypoints for Hermes A2A commands.
+
+Hermes core can call ``setup_argparse()`` for ``hermes a2a ...`` when its
+plugin CLI discovery supports standalone plugins. The package also exposes a
+standalone ``hermes-a2a`` console script so the plugin remains usable with
+Hermes versions that do not yet discover general plugin CLI commands.
+"""
 
 from __future__ import annotations
 
+import argparse
 import json
 from argparse import Namespace
 
@@ -104,3 +111,29 @@ def setup_argparse(subparser) -> None:
     task_cancel.add_argument("task_id")
 
     subparser.set_defaults(func=handle_cli)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the standalone ``hermes-a2a`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="hermes-a2a",
+        description="Operate the Hermes A2A bridge",
+    )
+    setup_argparse(parser)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Standalone console-script entrypoint for the A2A plugin."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = getattr(args, "func", None)
+    if handler is None:
+        parser.print_help()
+        return 2
+    handler(args)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through console script
+    raise SystemExit(main())

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -49,8 +49,9 @@ class A2AService:
             "local_tasks": len(self.store.list_tasks()),
         }
         payload["message"] = (
-            "Hermes A2A bridge is configured. Start `hermes a2a serve` to expose "
-            "the inbound JSON-RPC + SSE surface."
+            "Hermes A2A bridge is configured. Start `hermes-a2a serve` "
+            "(or `hermes a2a serve` on Hermes versions with standalone plugin "
+            "CLI discovery) to expose the inbound JSON-RPC + SSE surface."
         )
         return payload
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,33 @@
+"""Regression tests for the standalone hermes-a2a CLI entrypoint."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from hermes_a2a import cli  # noqa: E402
+
+
+class CliEntrypointTests(unittest.TestCase):
+    def test_main_dispatches_status_command(self) -> None:
+        with patch.dict("os.environ", {"A2A_STORE_PATH": ":memory:"}, clear=False):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = cli.main(["status"])
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["plugin"], "a2a")
+        self.assertEqual(payload["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a plugin-owned `hermes-a2a` console script so A2A CLI commands work without Hermes core standalone-plugin CLI discovery
- keep the existing `setup_argparse()` path for Hermes versions that support `hermes a2a ...`
- update status messaging and README to prefer `hermes-a2a` with `hermes a2a` as an optional compatibility path
- add a regression test for the standalone status command

## Verification
- `uv run python -m unittest discover -s tests -v`
- `uv run hermes-a2a status`
- static scan: no added hardcoded secrets, shell injection, eval/exec, pickle, or SQL injection patterns
- independent code review: passed
