### PR TITLE
feat: use Hermes runtime adapter by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The plugin is configured through environment variables:
 - `A2A_BEARER_TOKEN`
 - `A2A_EXPORTED_SKILLS`
 - `A2A_REMOTE_AGENTS_JSON`
+- `A2A_EXECUTION_ADAPTER` (`hermes` by default, set to `demo` for deterministic protocol testing)
+- `A2A_HERMES_COMMAND` (`hermes` by default)
+- `A2A_HERMES_EXTRA_ARGS` (optional shell-style arguments appended to `hermes chat`)
 
 `A2A_REMOTE_AGENTS_JSON` should decode to an object or list. Example:
 
@@ -129,5 +132,6 @@ The plugin is configured through environment variables:
 
 ## Notes
 
-- The current execution adapter is a demo adapter. The protocol, storage, and CLI surfaces are real, but the adapter is the seam where actual Hermes runtime integration should be added.
+- By default the inbound server routes A2A `message/send` and `message/stream` calls through `hermes chat -q ... --quiet`. Set `A2A_EXECUTION_ADAPTER=demo` to use the deterministic demo adapter for protocol testing without invoking a model.
+- The Hermes subprocess adapter is synchronous: streaming endpoints emit A2A SSE events after the underlying Hermes CLI call returns.
 - The SQLite store is durable by default and keeps task snapshots, event history, remote delegation tracking, and inbound push notification config state.

--- a/src/hermes_a2a/adapter.py
+++ b/src/hermes_a2a/adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Iterable
@@ -71,6 +72,155 @@ class HermesExecutionAdapter(ABC):
         metadata: dict | None = None,
     ) -> dict:
         """Return adapter-level terminal metadata for the task."""
+
+
+class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
+    """Adapter that delegates inbound A2A messages to the Hermes CLI runtime."""
+
+    def __init__(
+        self,
+        command: str = "hermes",
+        timeout_seconds: float = 120.0,
+        extra_args: list[str] | None = None,
+        runner=None,
+        max_output_chars: int = 20_000,
+    ) -> None:
+        self.command = command or "hermes"
+        self.timeout_seconds = timeout_seconds
+        self.extra_args = list(extra_args or [])
+        self.runner = runner or subprocess.run
+        self.max_output_chars = max(1, int(max_output_chars))
+
+    def _truncate(self, text: str) -> str:
+        if len(text) <= self.max_output_chars:
+            return text
+        omitted = len(text) - self.max_output_chars
+        return f"{text[: self.max_output_chars]}\n[truncated {omitted} chars]"
+
+    def _clean_stdout(self, stdout: str) -> str:
+        lines = [line for line in stdout.splitlines() if not line.startswith("session_id:")]
+        return self._truncate("\n".join(lines).strip())
+
+    def _run(self, task_id: str, context_id: str, message: str) -> Iterable[HermesEvent]:
+        yield HermesEvent(
+            kind="status",
+            state="working",
+            message="Hermes runtime execution started",
+            metadata={"task_id": task_id, "context_id": context_id},
+        )
+        command = [self.command, "chat", "--quiet", *self.extra_args, "-q", message]
+        try:
+            completed = self.runner(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            yield HermesEvent(
+                kind="status",
+                state="failed",
+                message=f"Hermes runtime timed out after {self.timeout_seconds:g}s",
+                metadata={"task_id": task_id, "context_id": context_id},
+            )
+            return
+        except OSError:
+            yield HermesEvent(
+                kind="status",
+                state="failed",
+                message="Hermes runtime command failed to start",
+                metadata={"task_id": task_id, "context_id": context_id},
+            )
+            return
+
+        stdout = self._clean_stdout(completed.stdout or "")
+        if completed.returncode != 0:
+            yield HermesEvent(
+                kind="status",
+                state="failed",
+                message="Hermes runtime failed",
+                metadata={
+                    "task_id": task_id,
+                    "context_id": context_id,
+                    "exit_code": str(completed.returncode),
+                },
+            )
+            return
+
+        if stdout:
+            yield HermesEvent(
+                kind="artifact",
+                state="working",
+                message="Hermes runtime response emitted",
+                text=stdout,
+                metadata={"artifact_id": "hermes-response"},
+            )
+        yield HermesEvent(
+            kind="status",
+            state="completed",
+            message="Hermes runtime execution completed",
+            metadata={"task_id": task_id, "context_id": context_id},
+        )
+
+    def start(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        metadata: dict | None = None,
+    ) -> Iterable[HermesEvent]:
+        del metadata
+        return self._run(task_id, context_id, message)
+
+    def continue_task(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        metadata: dict | None = None,
+    ) -> Iterable[HermesEvent]:
+        del metadata
+        return self._run(task_id, context_id, message)
+
+    def stream(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        metadata: dict | None = None,
+    ) -> Iterable[HermesEvent]:
+        del metadata
+        return self._run(task_id, context_id, message)
+
+    def cancel(
+        self,
+        task_id: str,
+        context_id: str,
+        metadata: dict | None = None,
+    ) -> Iterable[HermesEvent]:
+        del metadata
+        return [
+            HermesEvent(
+                kind="status",
+                state="cancelled",
+                message="Hermes runtime subprocess cancellation requested",
+                metadata={"task_id": task_id, "context_id": context_id},
+            )
+        ]
+
+    def finalize_task(
+        self,
+        task_id: str,
+        context_id: str,
+        metadata: dict | None = None,
+    ) -> dict:
+        return {
+            "taskId": task_id,
+            "contextId": context_id,
+            "adapter": "hermes-subprocess",
+            "command": self.command,
+            "metadata": metadata or {},
+        }
 
 
 class DemoHermesExecutionAdapter(HermesExecutionAdapter):

--- a/src/hermes_a2a/config.py
+++ b/src/hermes_a2a/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -37,6 +38,9 @@ class A2APluginConfig:
     remote_agents: list[RemoteAgentPreset] = field(default_factory=list)
     default_timeout_seconds: float = 10.0
     allow_runtime_write: bool = True
+    execution_adapter: str = "hermes"
+    hermes_command: str = "hermes"
+    hermes_extra_args: list[str] = field(default_factory=list)
 
     @property
     def resolved_public_base_url(self) -> str:
@@ -80,6 +84,9 @@ class A2APluginConfig:
                     }
                     for agent in self.remote_agents
                 ],
+                "execution_adapter": self.execution_adapter,
+                "hermes_command": self.hermes_command,
+                "hermes_extra_args": list(self.hermes_extra_args),
             },
         }
 
@@ -137,6 +144,9 @@ def load_config() -> A2APluginConfig:
     port = int(os.getenv("A2A_PORT", "8000").strip() or "8000")
     remote_agents = _parse_remote_agents(os.getenv("A2A_REMOTE_AGENTS_JSON", "").strip())
     exported_skills = _parse_exported_skills(os.getenv("A2A_EXPORTED_SKILLS", "").strip())
+    execution_adapter = os.getenv("A2A_EXECUTION_ADAPTER", "hermes").strip().lower() or "hermes"
+    hermes_command = os.getenv("A2A_HERMES_COMMAND", "hermes").strip() or "hermes"
+    hermes_extra_args = shlex.split(os.getenv("A2A_HERMES_EXTRA_ARGS", "").strip())
     return A2APluginConfig(
         host=host,
         port=port,
@@ -149,4 +159,7 @@ def load_config() -> A2APluginConfig:
             os.getenv("A2A_DEFAULT_TIMEOUT_SECONDS", "10").strip() or "10"
         ),
         allow_runtime_write=_truthy(os.getenv("A2A_ALLOW_RUNTIME_WRITE", "true")),
+        execution_adapter=execution_adapter,
+        hermes_command=hermes_command,
+        hermes_extra_args=hermes_extra_args,
     )

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -12,7 +12,11 @@ from typing import Iterable
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
-from .adapter import DemoHermesExecutionAdapter, HermesExecutionAdapter
+from .adapter import (
+    DemoHermesExecutionAdapter,
+    HermesExecutionAdapter,
+    HermesSubprocessExecutionAdapter,
+)
 from .config import A2APluginConfig, load_config
 from .mapping import (
     apply_hermes_event,
@@ -28,6 +32,21 @@ def _jsonrpc_error(request_id, code: int, message: str) -> dict:
     return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
 
 
+def _build_execution_adapter(config: A2APluginConfig) -> HermesExecutionAdapter:
+    if config.execution_adapter == "hermes":
+        return HermesSubprocessExecutionAdapter(
+            command=config.hermes_command,
+            timeout_seconds=config.default_timeout_seconds,
+            extra_args=config.hermes_extra_args,
+        )
+    if config.execution_adapter == "demo":
+        return DemoHermesExecutionAdapter()
+    raise ValueError(
+        "Unsupported A2A_EXECUTION_ADAPTER "
+        f"{config.execution_adapter!r}; expected 'hermes' or 'demo'"
+    )
+
+
 class A2AService:
     """Application service shared by Hermes tools, CLI, and HTTP handlers."""
 
@@ -39,7 +58,7 @@ class A2AService:
     ) -> None:
         self.config = config or load_config()
         self.store = store or SQLiteTaskStore(self.config.resolved_store_path)
-        self.adapter = adapter or DemoHermesExecutionAdapter()
+        self.adapter = adapter or _build_execution_adapter(self.config)
 
     def status_payload(self) -> dict:
         payload = self.config.status_dict()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,124 @@
+"""Tests for Hermes execution adapters."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys_path = str(ROOT / "src")
+if sys_path not in os.sys.path:
+    os.sys.path.insert(0, sys_path)
+
+from hermes_a2a.adapter import HermesSubprocessExecutionAdapter
+from hermes_a2a.config import A2APluginConfig
+from hermes_a2a.server import A2AService
+
+
+class HermesSubprocessAdapterTests(unittest.TestCase):
+    def test_start_invokes_hermes_chat_and_emits_text_artifact(self) -> None:
+        completed = mock.Mock(
+            returncode=0,
+            stdout="session_id: abc123\nHermes says hello\n",
+            stderr="",
+        )
+        adapter = HermesSubprocessExecutionAdapter(
+            command="hermes",
+            timeout_seconds=7.5,
+            extra_args=["--model", "test-model"],
+            runner=mock.Mock(return_value=completed),
+        )
+
+        events = list(adapter.start("task-1", "ctx-1", "hello"))
+
+        adapter.runner.assert_called_once_with(
+            ["hermes", "chat", "--quiet", "--model", "test-model", "-q", "hello"],
+            capture_output=True,
+            text=True,
+            timeout=7.5,
+        )
+        self.assertEqual(events[0].state, "working")
+        self.assertEqual(events[1].text, "Hermes says hello")
+        self.assertEqual(events[1].metadata["artifact_id"], "hermes-response")
+        self.assertEqual(events[-1].state, "completed")
+
+    def test_start_emits_sanitized_failed_status_when_hermes_command_fails(self) -> None:
+        completed = mock.Mock(returncode=2, stdout="", stderr="boom with /secret/path")
+        adapter = HermesSubprocessExecutionAdapter(
+            command="hermes",
+            timeout_seconds=1,
+            runner=mock.Mock(return_value=completed),
+        )
+
+        events = list(adapter.start("task-1", "ctx-1", "hello"))
+
+        self.assertEqual(events[-1].state, "failed")
+        self.assertEqual(events[-1].message, "Hermes runtime failed")
+        self.assertEqual(events[-1].metadata["exit_code"], "2")
+
+    def test_start_emits_failed_status_when_hermes_command_times_out(self) -> None:
+        adapter = HermesSubprocessExecutionAdapter(
+            command="hermes",
+            timeout_seconds=1,
+            runner=mock.Mock(side_effect=subprocess.TimeoutExpired("hermes", 1)),
+        )
+
+        events = list(adapter.start("task-1", "ctx-1", "hello"))
+
+        self.assertEqual(events[-1].state, "failed")
+        self.assertIn("timed out", events[-1].message)
+
+    def test_start_emits_sanitized_failed_status_when_hermes_command_cannot_start(self) -> None:
+        adapter = HermesSubprocessExecutionAdapter(
+            command="hermes",
+            timeout_seconds=1,
+            runner=mock.Mock(side_effect=OSError("/secret/path missing")),
+        )
+
+        events = list(adapter.start("task-1", "ctx-1", "hello"))
+
+        self.assertEqual(events[-1].state, "failed")
+        self.assertEqual(events[-1].message, "Hermes runtime command failed to start")
+
+    def test_start_truncates_large_success_output(self) -> None:
+        completed = mock.Mock(returncode=0, stdout="abcdef", stderr="")
+        adapter = HermesSubprocessExecutionAdapter(
+            command="hermes",
+            max_output_chars=3,
+            runner=mock.Mock(return_value=completed),
+        )
+
+        events = list(adapter.start("task-1", "ctx-1", "hello"))
+
+        self.assertEqual(events[1].text, "abc\n[truncated 3 chars]")
+
+    def test_service_uses_hermes_adapter_when_configured(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = A2APluginConfig(
+                store_path=str(Path(tmpdir) / "state.db"),
+                execution_adapter="hermes",
+                hermes_command="hermes",
+            )
+            service = A2AService(config=config)
+            try:
+                self.assertIsInstance(service.adapter, HermesSubprocessExecutionAdapter)
+            finally:
+                service.close()
+    def test_service_rejects_unknown_execution_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = A2APluginConfig(
+                store_path=str(Path(tmpdir) / "state.db"),
+                execution_adapter="typo",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Unsupported A2A_EXECUTION_ADAPTER"):
+                A2AService(config=config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,10 +33,30 @@ class ConfigTests(unittest.TestCase):
                 config = load_config()
 
         self.assertEqual(config.exported_skills, ["delegate", "inspect"])
+        self.assertEqual(config.execution_adapter, "hermes")
         self.assertEqual(len(config.remote_agents), 1)
         self.assertEqual(config.remote_agents[0].alias, "demo")
         self.assertEqual(config.remote_agents[0].url, "https://example.test")
         self.assertEqual(
             config.remote_agents[0].headers,
             {"Authorization": "Bearer x"},
+        )
+
+    def test_load_config_parses_hermes_runtime_adapter_settings(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                "A2A_EXECUTION_ADAPTER": "hermes",
+                "A2A_HERMES_COMMAND": "/opt/bin/hermes",
+                "A2A_HERMES_EXTRA_ARGS": "--model test-model --provider test-provider",
+            },
+            clear=True,
+        ):
+            config = load_config()
+
+        self.assertEqual(config.execution_adapter, "hermes")
+        self.assertEqual(config.hermes_command, "/opt/bin/hermes")
+        self.assertEqual(
+            config.hermes_extra_args,
+            ["--model", "test-model", "--provider", "test-provider"],
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -28,6 +28,7 @@ class ServerTests(unittest.TestCase):
             port=0,
             store_path=str(Path(self.tmpdir.name) / "server.db"),
             exported_skills=["delegate"],
+            execution_adapter="demo",
         )
         self.server = create_server(config=config)
         self.server.start()


### PR DESCRIPTION
## Summary
- Add a Hermes subprocess execution adapter for inbound A2A tasks
- Make Hermes the default execution adapter and keep `A2A_EXECUTION_ADAPTER=demo` for deterministic protocol tests
- Sanitize runtime failure messages, truncate large successful outputs, and reject unknown adapter names

## Test Plan
- `uv run python -m unittest discover -s tests -v`
- Static scan for hardcoded secrets, shell injection, eval/exec, unsafe deserialization, and SQL formatting
- Independent reviewer pass
