### PR TITLE
docs: add repository agent guidance

### DIFF
--- a/.agents/skills/maintainer-comments/SKILL.md
+++ b/.agents/skills/maintainer-comments/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: maintainer-comments
+description: Add explanatory code comments for maintainers new to the Hermes A2A plugin. Use when asked to annotate code, add maintainer comments, improve codebase onboarding, explain non-obvious protocol mapping, or make this repository easier to understand without changing behavior.
+---
+
+# Maintainer Comments
+
+## Overview
+
+Use this skill to add high-signal comments that help new maintainers understand
+the Hermes A2A plugin quickly. The goal is to explain non-obvious intent,
+boundaries, protocol compatibility, and persistence behavior without narrating
+self-evident code.
+
+## Workflow
+
+1. Inspect the current code path before editing.
+   Read nearby tests and callers before adding comments. Preserve behavior; this
+   is a comment-only workflow unless the user explicitly asks for code changes.
+   Check the official A2A spec when commenting protocol behavior:
+   https://a2a-protocol.org/latest/specification/
+
+2. Identify comments worth adding.
+   Add comments where a maintainer would otherwise need to trace multiple files,
+   protocol docs, or runtime contracts to understand why the code is shaped that
+   way. Prefer comments near boundary crossings: A2A protocol to Hermes runtime,
+   Hermes tool to HTTP client, adapter event to task/artifact/status payload, and
+   SQLite snapshot to public response. Skip obvious assignments, imports, simple
+   constructors, and direct field copies.
+
+3. Write comments for maintainers.
+   Explain why the code exists, what contract it protects, or which
+   compatibility behavior it preserves. Keep comments short. Prefer docstrings
+   for public helpers, service methods, adapters, and classes. Prefer inline
+   comments only before tricky blocks, compatibility decisions, protocol
+   translations, or intentional error-handling choices. If a comment repeats a
+   function name or restates a single line, delete it.
+
+4. Verify the sweep.
+   Run or update targeted tests only if the user also requested behavior
+   changes. For comment-only changes, inspect the diff and confirm no executable
+   code changed. Report any intentionally skipped areas where comments would
+   become stale or speculative.
+
+## Repo Hotspots
+
+Focus comments around these files when doing a maintainer sweep:
+
+- `src/hermes_a2a/server.py`: inbound HTTP, JSON-RPC dispatch, SSE streaming,
+  auth, request errors, push notification delivery, and service orchestration.
+- `src/hermes_a2a/client.py`: outbound A2A requests, remote agent resolution,
+  JSON-RPC request construction, streaming response parsing, and remote errors.
+- `src/hermes_a2a/mapping.py`: AgentCard generation, Hermes event to A2A task
+  mapping, message/part/artifact/status conversion, and SSE payload shape.
+- `src/hermes_a2a/__init__.py`, `src/hermes_a2a/tools.py`, and
+  `src/hermes_a2a/adapter.py`: Hermes plugin registration, tool handler
+  contracts, and the boundary between demo execution and real Hermes runtime
+  integration.
+- `src/hermes_a2a/store.py`: durable task snapshots, event journals, push
+  configs, and remote delegation bookkeeping.
+- `src/hermes_a2a/config.py`: environment-driven configuration, remote agent
+  presets, public URL derivation, and store path resolution.
+
+## Comment Quality Bar
+
+Good comments:
+
+- "Keep the remote mapping separate from the task snapshot so local task IDs can
+  remain stable even when a delegated agent uses its own task ID."
+- "This endpoint is unauthenticated because A2A discovery requires the public
+  agent card before a client knows which security scheme to use."
+- "The adapter emits Hermes-native events; mapping.py is the only place that
+  should translate those into A2A task/status/artifact shapes."
+
+Avoid comments like:
+
+- "Set task_id to the task ID."
+- "Import json."
+- "Loop over events."
+- Comments that claim official A2A compliance without checking the current
+  spec and the emitted wire shape.

--- a/.agents/skills/maintainer-comments/agents/openai.yaml
+++ b/.agents/skills/maintainer-comments/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Maintainer Comments"
+  short_description: "Add high-signal maintainer comments"
+  default_prompt: "Use $maintainer-comments to annotate non-obvious code paths for new maintainers while preserving behavior."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# Repository Instructions
+
+## Project Shape
+
+This repository is the `a2a` Hermes plugin. It supports two load paths:
+
+- packaged plugin entry point: `hermes_a2a` from `pyproject.toml`
+- directory plugin compatibility from the repo root shims: `__init__.py`,
+  `schemas.py`, and `tools.py`
+
+Keep real implementation under `src/hermes_a2a/`. Root-level files should stay
+thin compatibility shims unless the Hermes directory-plugin contract requires
+otherwise.
+
+## A2A Protocol Compliance
+
+The official A2A protocol specification is:
+
+https://a2a-protocol.org/latest/specification/
+
+When changing any public A2A surface, verify against the latest official spec,
+not only existing tests or README examples. Protocol-sensitive files include:
+
+- `src/hermes_a2a/server.py` for inbound HTTP, JSON-RPC, SSE, auth, and errors
+- `src/hermes_a2a/client.py` for outbound A2A JSON-RPC calls
+- `src/hermes_a2a/mapping.py` for AgentCard, tasks, messages, parts, artifacts,
+  statuses, and stream events
+- `src/hermes_a2a/store.py` for persisted protocol state
+- `tests/test_server.py` for end-to-end protocol regression coverage
+
+Treat spec compliance as a contract. If this plugin declares A2A 1.0 support,
+then JSON-RPC methods, AgentCard fields, version handling, task/message/part
+schemas, response wrappers, streaming events, push notification config shapes,
+and errors must match the official A2A 1.0 spec.
+
+Do not introduce new protocol aliases or compatibility fields silently. If
+legacy support is needed, document it in code/tests and keep official A2A
+behavior as the default path.
+
+## Hermes Plugin Conventions
+
+- Register tools and CLI commands in `src/hermes_a2a/__init__.py`.
+- Keep model-facing tool schemas in `src/hermes_a2a/schemas.py`.
+- Tool handlers in `src/hermes_a2a/tools.py` must accept `args, **kwargs` and
+  return JSON strings on both success and error paths.
+- Keep `plugin.yaml` aligned with registered tools.
+- The adapter boundary is `src/hermes_a2a/adapter.py`; do not mix Hermes runtime
+  execution details into protocol mapping code.
+- Keep configuration in `src/hermes_a2a/config.py` and prefer environment
+  variables already used by the repo before adding new ones.
+
+## Testing
+
+Use the repo's unittest suite:
+
+```bash
+uv run python -m unittest discover -s tests -v
+```
+
+If uv cannot read or write the default cache in a sandboxed environment, use a
+writable cache path:
+
+```bash
+env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v
+```
+
+Add or update regression tests when fixing protocol bugs. For A2A compliance
+work, prefer tests that exercise the public HTTP/JSON-RPC/SSE behavior through
+`create_server()` instead of only testing helpers.
+
+## Change Discipline
+
+- Keep changes narrowly scoped to the protocol, plugin, or CLI surface being
+  edited.
+- Do not rewrite storage or mapping layers just to clean up style.
+- Preserve durable SQLite behavior unless the task explicitly changes the state
+  model.
+- Update README examples when public commands, environment variables, or
+  protocol behavior change.
+- Before claiming compliance, run the test suite and include at least one check
+  against the official A2A method/card shape affected by the change.


### PR DESCRIPTION
## Summary
Add repository-level guidance for future agents working on the Hermes A2A plugin, including A2A protocol compliance expectations and a project-local skill for maintainer-focused code comments.

## Key Changes
- Add AGENTS.md with project shape, A2A compliance guidance, Hermes plugin conventions, testing commands, and change discipline.
- Add .agents/skills/maintainer-comments/SKILL.md to guide future maintainer-comment sweeps across protocol, plugin runtime, persistence, and config boundaries.
- Add .agents/skills/maintainer-comments/agents/openai.yaml with UI metadata and a default prompt for the repo-local skill.

## Validation
- Ran: python3 /Users/kaitian/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/maintainer-comments
- Result: Skill is valid!