### PR TITLE
docs: refresh a2a maintainer guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,35 @@
 This repository is the `a2a` Hermes plugin. It supports two load paths:
 
 - packaged plugin entry point: `hermes_a2a` from `pyproject.toml`
+- standalone console script: `hermes-a2a` from `src/hermes_a2a/cli.py`
 - directory plugin compatibility from the repo root shims: `__init__.py`,
   `schemas.py`, and `tools.py`
 
 Keep real implementation under `src/hermes_a2a/`. Root-level files should stay
 thin compatibility shims unless the Hermes directory-plugin contract requires
 otherwise.
+
+## Implementation Map
+
+- `src/hermes_a2a/__init__.py` registers the Hermes tools and the `a2a` CLI
+  command group.
+- `src/hermes_a2a/cli.py` owns both `hermes a2a ...` command wiring and the
+  fallback `hermes-a2a` console script.
+- `src/hermes_a2a/config.py` owns all environment parsing and computed URLs.
+- `src/hermes_a2a/adapter.py` is the only boundary for executing Hermes runtime
+  work. The `hermes` adapter shells out to `hermes chat --quiet ... -q`, while
+  the `demo` adapter is for deterministic protocol tests.
+- `src/hermes_a2a/server.py` owns the inbound HTTP, JSON-RPC, SSE, auth, push
+  notification, and task orchestration surface.
+- `src/hermes_a2a/client.py` is the minimal outbound A2A JSON-RPC/SSE client
+  used by remote delegation tools.
+- `src/hermes_a2a/mapping.py` translates between Hermes adapter events and A2A
+  AgentCard, task, message, part, artifact, status, and SSE event shapes.
+- `src/hermes_a2a/store.py` is the durable SQLite store for task snapshots,
+  event journals, push configs, and outbound remote-task mappings.
+- `src/hermes_a2a/schemas.py` contains the model-facing Hermes tool schemas.
+- `src/hermes_a2a/tools.py` contains Hermes tool handlers and must return JSON
+  strings on both success and error paths.
 
 ## A2A Protocol Compliance
 
@@ -25,7 +48,8 @@ not only existing tests or README examples. Protocol-sensitive files include:
 - `src/hermes_a2a/client.py` for outbound A2A JSON-RPC calls
 - `src/hermes_a2a/mapping.py` for AgentCard, tasks, messages, parts, artifacts,
   statuses, and stream events
-- `src/hermes_a2a/store.py` for persisted protocol state
+- `src/hermes_a2a/store.py` for persisted protocol state, event replay, push
+  configs, and remote delegation bookkeeping
 - `tests/test_server.py` for end-to-end protocol regression coverage
 
 Treat spec compliance as a contract. If this plugin declares A2A 1.0 support,
@@ -36,6 +60,34 @@ and errors must match the official A2A 1.0 spec.
 Do not introduce new protocol aliases or compatibility fields silently. If
 legacy support is needed, document it in code/tests and keep official A2A
 behavior as the default path.
+
+## Runtime Surfaces
+
+The current inbound server exposes:
+
+- `GET /.well-known/agent-card.json`
+- `POST /rpc` for `message/send`, `message/stream`, `tasks/get`,
+  `tasks/cancel`, `tasks/resubscribe`, and push notification config methods
+- `GET /tasks/<task_id>/events?after_seq=<seq>` for SSE event replay
+
+The current Hermes tools are:
+
+- `a2a_status`
+- `a2a_list_agents`
+- `a2a_get_task`
+- `a2a_cancel_task`
+- `a2a_delegate`
+
+The current CLI commands are:
+
+- `hermes a2a status`
+- `hermes a2a card`
+- `hermes a2a serve`
+- `hermes a2a agents list`
+- `hermes a2a task get <id>`
+- `hermes a2a task cancel <id>`
+- `hermes-a2a ...` with the same subcommands for Hermes versions that do not
+  discover standalone plugin CLI commands
 
 ## Hermes Plugin Conventions
 
@@ -48,6 +100,29 @@ behavior as the default path.
   execution details into protocol mapping code.
 - Keep configuration in `src/hermes_a2a/config.py` and prefer environment
   variables already used by the repo before adding new ones.
+- Keep `README.md` in sync when public commands, config variables, or protocol
+  behavior changes.
+
+## Configuration
+
+Current environment variables parsed by `src/hermes_a2a/config.py`:
+
+- `A2A_HOST`
+- `A2A_PORT`
+- `A2A_PUBLIC_BASE_URL`
+- `A2A_STORE_PATH`
+- `A2A_BEARER_TOKEN`
+- `A2A_EXPORTED_SKILLS`
+- `A2A_REMOTE_AGENTS_JSON`
+- `A2A_DEFAULT_TIMEOUT_SECONDS`
+- `A2A_ALLOW_RUNTIME_WRITE`
+- `A2A_EXECUTION_ADAPTER` (`hermes` by default, `demo` for deterministic tests)
+- `A2A_HERMES_COMMAND`
+- `A2A_HERMES_EXTRA_ARGS`
+
+Prefer extending this config object over reading environment variables directly
+from server, client, adapter, tool, or CLI code. Keep config parsing covered by
+`tests/test_config.py`.
 
 ## Testing
 
@@ -67,6 +142,22 @@ env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s 
 Add or update regression tests when fixing protocol bugs. For A2A compliance
 work, prefer tests that exercise the public HTTP/JSON-RPC/SSE behavior through
 `create_server()` instead of only testing helpers.
+
+Test ownership map:
+
+- `tests/test_server.py` covers inbound JSON-RPC/SSE behavior, push config CRUD,
+  and loopback outbound delegation against a local server.
+- `tests/test_adapter.py` covers Hermes subprocess adapter command construction,
+  output sanitization, timeout/startup failure handling, truncation, and adapter
+  selection.
+- `tests/test_store.py` covers durable SQLite task, event, push config, and
+  remote-task persistence.
+- `tests/test_tools.py` covers JSON-string Hermes tool behavior and status
+  payloads.
+- `tests/test_config.py` covers environment parsing.
+- `tests/test_register.py`, `tests/test_root_plugin.py`, and `tests/test_shims.py`
+  cover packaged and directory-plugin registration paths.
+- `tests/test_cli_entrypoint.py` covers the standalone `hermes-a2a` entrypoint.
 
 ## Change Discipline
 

--- a/src/hermes_a2a/adapter.py
+++ b/src/hermes_a2a/adapter.py
@@ -11,7 +11,12 @@ from typing import Iterable
 
 @dataclass(slots=True)
 class HermesEvent:
-    """Structured event emitted by a Hermes execution adapter."""
+    """Hermes-native event before it is translated into A2A task shapes.
+
+    Adapters should stay ignorant of AgentCard, Task, Part, and SSE schemas.
+    `mapping.py` is the single boundary that turns these events into protocol
+    payloads.
+    """
 
     kind: str
     state: str
@@ -23,7 +28,11 @@ class HermesEvent:
 
 
 class HermesExecutionAdapter(ABC):
-    """Stable interface between Hermes internals and A2A protocol surfaces."""
+    """Stable interface between Hermes internals and A2A protocol surfaces.
+
+    The service layer drives task lifecycle decisions; adapter implementations
+    only report runtime progress, artifacts, and terminal metadata.
+    """
 
     @abstractmethod
     def start(
@@ -98,6 +107,8 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
         return f"{text[: self.max_output_chars]}\n[truncated {omitted} chars]"
 
     def _clean_stdout(self, stdout: str) -> str:
+        # Hermes CLI sessions may print bookkeeping lines that are useful for
+        # local shells but should not become user-visible A2A artifacts.
         lines = [line for line in stdout.splitlines() if not line.startswith("session_id:")]
         return self._truncate("\n".join(lines).strip())
 
@@ -224,7 +235,12 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
 
 
 class DemoHermesExecutionAdapter(HermesExecutionAdapter):
-    """Fallback adapter used until a real Hermes runtime is wired in."""
+    """Deterministic adapter for tests and local protocol debugging.
+
+    Keep this adapter predictable: server and tool tests use message text to
+    force status, data, file, and input-required branches without invoking a
+    model or subprocess.
+    """
 
     def _run(
         self,

--- a/src/hermes_a2a/client.py
+++ b/src/hermes_a2a/client.py
@@ -19,7 +19,11 @@ def resolve_agent_target(
     target: str,
     config: A2APluginConfig,
 ) -> tuple[str, dict[str, str], str]:
-    """Resolve a direct URL or configured alias into a concrete agent target."""
+    """Resolve a direct URL or configured alias into a concrete agent target.
+
+    Direct URLs intentionally receive no preset headers; aliases are the place
+    for persisted per-agent auth metadata from `A2A_REMOTE_AGENTS_JSON`.
+    """
     stripped = target.strip()
     if stripped.startswith("http://") or stripped.startswith("https://"):
         return stripped.rstrip("/"), {}, "direct"
@@ -32,7 +36,11 @@ def resolve_agent_target(
 
 
 class A2AClient:
-    """Small JSON-RPC client for remote A2A agents."""
+    """Small JSON-RPC client for remote A2A agents.
+
+    The Hermes tool layer uses this client for outbound delegation. Keep it
+    protocol-shaped and free of local task-store decisions.
+    """
 
     def __init__(
         self,
@@ -119,6 +127,8 @@ class A2AClient:
                     event_name = line.split(":", 1)[1].strip()
                     continue
                 if line.startswith("data:"):
+                    # The local server emits one JSON object per SSE `data:`
+                    # line, so this parser deliberately stays line-oriented.
                     data = json.loads(line.split(":", 1)[1].strip())
                     yield {"event": event_name, "data": data}
 

--- a/src/hermes_a2a/mapping.py
+++ b/src/hermes_a2a/mapping.py
@@ -15,7 +15,13 @@ def utc_timestamp() -> str:
 
 
 def extract_text_from_message(message: dict | str | None) -> str:
-    """Extract a user-facing text payload from a loose A2A message shape."""
+    """Extract text from the A2A message variants this bridge accepts.
+
+    The official path is text parts, but this helper also accepts a few loose
+    shapes so tool callers and older tests can share the same adapter boundary.
+    Keep any compatibility expansion here instead of spreading message parsing
+    through the service or adapter layers.
+    """
     if message is None:
         return ""
     if isinstance(message, str):
@@ -64,6 +70,7 @@ def build_file_part(uri: str) -> dict:
 
 
 def build_artifact_from_event(event: HermesEvent) -> dict | None:
+    """Turn one Hermes artifact event into the narrow A2A artifact shape."""
     artifact_id = event.metadata.get("artifact_id", "artifact")
     if event.text:
         parts = [build_text_part(event.text)]
@@ -87,6 +94,7 @@ def build_initial_task(
     direction: str,
     metadata: dict | None = None,
 ) -> dict:
+    """Create the task snapshot before any runtime event has been applied."""
     timestamp = utc_timestamp()
     return {
         "kind": "task",
@@ -118,12 +126,19 @@ def build_initial_task(
 
 
 def apply_hermes_event(task: dict, event: HermesEvent) -> dict:
-    """Apply one adapter event to a task snapshot and return an event envelope."""
+    """Apply one adapter event to a task snapshot and return an SSE envelope.
+
+    This is the main protocol translation point: adapters emit Hermes-native
+    status/artifact events, while server, client, and store code deal in A2A
+    task snapshots and event names.
+    """
     timestamp = utc_timestamp()
     task["updatedAt"] = timestamp
     task["historyLength"] = int(task.get("historyLength", 0)) + 1
 
     if event.kind in {"status", "requires_input"}:
+        # Status events mutate the task's terminal state and are also appended
+        # to message history so resumed clients can reconstruct the exchange.
         task["status"] = {
             "state": event.state,
             "timestamp": timestamp,
@@ -169,7 +184,7 @@ def apply_hermes_event(task: dict, event: HermesEvent) -> dict:
 
 
 def build_agent_card(config: A2APluginConfig) -> dict:
-    """Build the public agent card published by the plugin."""
+    """Build the public discovery card for this Hermes bridge."""
     skills = [
         {
             "id": skill,
@@ -202,7 +217,7 @@ def build_agent_card(config: A2APluginConfig) -> dict:
 
 
 def make_sse_payload(event_name: str, data: dict) -> bytes:
-    """Encode an SSE event payload."""
+    """Encode one A2A task update as a Server-Sent Event frame."""
     import json
 
     return (

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -48,7 +48,11 @@ def _build_execution_adapter(config: A2APluginConfig) -> HermesExecutionAdapter:
 
 
 class A2AService:
-    """Application service shared by Hermes tools, CLI, and HTTP handlers."""
+    """Application service shared by Hermes tools, CLI, and HTTP handlers.
+
+    This class owns orchestration across config, storage, adapters, and
+    protocol mapping so the HTTP handler remains a thin transport layer.
+    """
 
     def __init__(
         self,
@@ -85,6 +89,9 @@ class A2AService:
         stream: bool,
         metadata: dict | None = None,
     ) -> Iterable:
+        # Existing tasks represent continuation. Streaming still uses the
+        # adapter's streaming method because the transport contract, not task
+        # freshness, decides how updates should be delivered to the caller.
         existing = self.store.get_task(task_id)
         if existing is None:
             return self.adapter.stream(task_id, context_id, message_text, metadata) if stream else self.adapter.start(task_id, context_id, message_text, metadata)
@@ -124,6 +131,8 @@ class A2AService:
             task = build_initial_task(task_id, context_id, message_text, direction="inbound")
         events: list[dict] = []
 
+        # Persist each mapped event before push delivery. If a callback fails,
+        # resubscribe/event replay can still return the durable update.
         for adapter_event in self._iter_adapter_events(
             task_id,
             context_id,
@@ -221,6 +230,8 @@ class _RequestHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         parsed = urlparse(self.path)
         if parsed.path == "/.well-known/agent-card.json":
+            # Discovery is public so clients can learn the agent's advertised
+            # transport and security scheme before making authenticated calls.
             self._send_json(self._service.agent_card())
             return
 
@@ -267,6 +278,8 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
             if method == "message/stream":
                 task, events = self._service.send_message(params, stream=True)
+                # This implementation buffers adapter output, then emits a
+                # compact SSE replay plus a final task snapshot for clients.
                 self.send_response(HTTPStatus.OK)
                 self.send_header("Content-Type", "text/event-stream")
                 self.send_header("Cache-Control", "no-cache")

--- a/src/hermes_a2a/store.py
+++ b/src/hermes_a2a/store.py
@@ -11,7 +11,13 @@ from .mapping import utc_timestamp
 
 
 class SQLiteTaskStore:
-    """Persist task snapshots, event journals, and push configs."""
+    """Persist protocol-facing state outside the transport layer.
+
+    Task snapshots are optimized for current `tasks/get` responses. The event
+    journal is kept separately so SSE resubscribe can replay updates, and remote
+    delegation mappings stay outside snapshots so local task IDs can remain the
+    lookup key for Hermes tools.
+    """
 
     def __init__(self, path: str) -> None:
         self.path = str(Path(path).expanduser())

--- a/src/hermes_a2a/tools.py
+++ b/src/hermes_a2a/tools.py
@@ -52,6 +52,7 @@ def tool_a2a_list_agents(args: dict[str, Any], **kwargs) -> str:
 
 
 def _refresh_remote_task(service: A2AService, task_id: str) -> dict:
+    """Return the local snapshot, refreshing delegated tasks from their agent."""
     task = service.get_task(task_id)
     remote = service.store.get_remote_task(task_id)
     if not remote:
@@ -127,6 +128,8 @@ def tool_a2a_delegate(args: dict[str, Any], **kwargs) -> str:
         card = client.get_agent_card()
 
         if mode == "stream":
+            # Tool callers receive both the raw remote event stream and the
+            # final task snapshot; the store only persists the final task.
             events = list(client.stream_message(message, task_id=task_id, context_id=context_id))
             final_task = None
             for event in events:
@@ -146,6 +149,8 @@ def tool_a2a_delegate(args: dict[str, Any], **kwargs) -> str:
             {"remoteAgentUrl": agent_url, "resolvedTarget": resolved_target}
         )
         service.store.upsert_task(task, direction="outbound")
+        # Keep a local lookup from tool-facing task ID to the remote agent URL
+        # so later get/cancel calls can be routed back to the same agent.
         service.store.set_remote_task(task["id"], agent_url, task["id"])
         if mode == "poll":
             return json.dumps({"card": card, "task": task, "mode": "poll"})


### PR DESCRIPTION
## Summary
Refresh the repo guidance and source comments so maintainers can understand the current Hermes A2A plugin layout and protocol boundaries faster.

## Key Changes
- update AGENTS.md with the current implementation map, runtime surfaces, config variables, and test ownership
- add maintainer-focused comments around the adapter-to-protocol boundary in src/hermes_a2a/adapter.py and src/hermes_a2a/mapping.py
- document orchestration and discovery decisions in src/hermes_a2a/server.py
- clarify outbound delegation and remote task lookup behavior in src/hermes_a2a/client.py, src/hermes_a2a/store.py, and src/hermes_a2a/tools.py

## Validation
- env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v
- git diff --check

## Notes
- The test suite still emits the pre-existing sqlite ResourceWarning during one server test, but the run passes cleanly.