### PR TITLE
fix: align A2A JSON-RPC with spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,14 @@ behavior as the default path.
 The current inbound server exposes:
 
 - `GET /.well-known/agent-card.json`
-- `POST /rpc` for `message/send`, `message/stream`, `tasks/get`,
-  `tasks/cancel`, `tasks/resubscribe`, and push notification config methods
-- `GET /tasks/<task_id>/events?after_seq=<seq>` for SSE event replay
+- `POST /rpc` for official A2A 1.0 JSON-RPC methods: `SendMessage`,
+  `SendStreamingMessage`, `GetTask`, `ListTasks`, `CancelTask`,
+  `SubscribeToTask`, `CreateTaskPushNotificationConfig`,
+  `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfig`,
+  `DeleteTaskPushNotificationConfig`, and `GetExtendedAgentCard`
+
+Legacy slash-style JSON-RPC methods and custom SSE replay endpoints are not
+part of the public A2A surface.
 
 The current Hermes tools are:
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ uv run hermes-a2a card
 
 - Inbound server:
   - `GET /.well-known/agent-card.json`
-  - `POST /rpc` for `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`,
-    `tasks/resubscribe`, and push notification config methods
+  - `POST /rpc` for the official A2A 1.0 JSON-RPC methods:
+    `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`,
+    `CancelTask`, `SubscribeToTask`, `CreateTaskPushNotificationConfig`,
+    `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfig`,
+    `DeleteTaskPushNotificationConfig`, and `GetExtendedAgentCard`
 - Outbound Hermes tools:
   - `a2a_status`
   - `a2a_list_agents`
@@ -132,6 +135,15 @@ The plugin is configured through environment variables:
 
 ## Notes
 
-- By default the inbound server routes A2A `message/send` and `message/stream` calls through `hermes chat -q ... --quiet`. Set `A2A_EXECUTION_ADAPTER=demo` to use the deterministic demo adapter for protocol testing without invoking a model.
-- The Hermes subprocess adapter is synchronous: streaming endpoints emit A2A SSE events after the underlying Hermes CLI call returns.
-- The SQLite store is durable by default and keeps task snapshots, event history, remote delegation tracking, and inbound push notification config state.
+- JSON-RPC requests must include `A2A-Version: 1.0`. Legacy slash-style methods
+  such as `message/send` and old task/message/part response fields are not
+  supported.
+- By default the inbound server routes A2A `SendMessage` and
+  `SendStreamingMessage` calls through `hermes chat -q ... --quiet`. Set
+  `A2A_EXECUTION_ADAPTER=demo` to use the deterministic demo adapter for
+  protocol testing without invoking a model.
+- The Hermes subprocess adapter is synchronous: streaming endpoints emit A2A
+  JSON-RPC SSE `data:` frames after the underlying Hermes CLI call returns.
+- The SQLite store is durable by default and keeps official A2A task snapshots,
+  StreamResponse event payloads, remote delegation tracking, and named inbound
+  push notification config state.

--- a/src/hermes_a2a/client.py
+++ b/src/hermes_a2a/client.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 
 import json
 import urllib.error
-import urllib.parse
 import urllib.request
 from typing import Iterator
+from uuid import uuid4
 
-from .config import A2APluginConfig, RemoteAgentPreset
+from .config import A2APluginConfig
+from .mapping import build_text_part
+from .protocol import (
+    METHOD_CANCEL_TASK,
+    METHOD_GET_TASK,
+    METHOD_SEND_MESSAGE,
+    METHOD_SEND_STREAMING_MESSAGE,
+    PROTOCOL_VERSION,
+    task_name,
+)
 
 
 class A2AClientError(RuntimeError):
@@ -60,7 +69,7 @@ class A2AClient:
     ):
         url = f"{self.base_url}{path}"
         payload = None
-        headers = {"Accept": accept, **self.headers}
+        headers = {"Accept": accept, "A2A-Version": PROTOCOL_VERSION, **self.headers}
         if body is not None:
             payload = json.dumps(body).encode("utf-8")
             headers["Content-Type"] = "application/json"
@@ -88,18 +97,25 @@ class A2AClient:
         request = {
             "jsonrpc": "2.0",
             "id": "delegate",
-            "method": "message/send",
+            "method": METHOD_SEND_MESSAGE,
             "params": {
-                "taskId": task_id or None,
-                "contextId": context_id or None,
-                "message": {"role": "user", "parts": [{"type": "text", "text": message}]},
+                "message": {
+                    "messageId": str(uuid4()),
+                    "role": "ROLE_USER",
+                    "parts": [build_text_part(message)],
+                    **({"taskId": task_id} if task_id else {}),
+                    **({"contextId": context_id} if context_id else {}),
+                },
             },
         }
         with self._request("/rpc", request) as response:
             payload = json.loads(response.read().decode("utf-8"))
         if "error" in payload:
             raise A2AClientError(payload["error"]["message"])
-        return payload["result"]
+        result = payload.get("result") or {}
+        if "task" not in result:
+            raise A2AClientError("Remote SendMessage response did not contain result.task")
+        return result["task"]
 
     def stream_message(
         self,
@@ -110,34 +126,34 @@ class A2AClient:
         request = {
             "jsonrpc": "2.0",
             "id": "stream",
-            "method": "message/stream",
+            "method": METHOD_SEND_STREAMING_MESSAGE,
             "params": {
-                "taskId": task_id or None,
-                "contextId": context_id or None,
-                "message": {"role": "user", "parts": [{"type": "text", "text": message}]},
+                "message": {
+                    "messageId": str(uuid4()),
+                    "role": "ROLE_USER",
+                    "parts": [build_text_part(message)],
+                    **({"taskId": task_id} if task_id else {}),
+                    **({"contextId": context_id} if context_id else {}),
+                },
             },
         }
         with self._request("/rpc", request, accept="text/event-stream") as response:
-            event_name = "message"
             for raw_line in response:
                 line = raw_line.decode("utf-8").strip()
                 if not line:
                     continue
-                if line.startswith("event:"):
-                    event_name = line.split(":", 1)[1].strip()
-                    continue
                 if line.startswith("data:"):
-                    # The local server emits one JSON object per SSE `data:`
-                    # line, so this parser deliberately stays line-oriented.
-                    data = json.loads(line.split(":", 1)[1].strip())
-                    yield {"event": event_name, "data": data}
+                    payload = json.loads(line.split(":", 1)[1].strip())
+                    if "error" in payload:
+                        raise A2AClientError(payload["error"]["message"])
+                    yield payload["result"]
 
     def get_task(self, task_id: str) -> dict:
         request = {
             "jsonrpc": "2.0",
             "id": "task-get",
-            "method": "tasks/get",
-            "params": {"id": task_id},
+            "method": METHOD_GET_TASK,
+            "params": {"name": task_name(task_id)},
         }
         with self._request("/rpc", request) as response:
             payload = json.loads(response.read().decode("utf-8"))
@@ -149,8 +165,8 @@ class A2AClient:
         request = {
             "jsonrpc": "2.0",
             "id": "task-cancel",
-            "method": "tasks/cancel",
-            "params": {"id": task_id},
+            "method": METHOD_CANCEL_TASK,
+            "params": {"name": task_name(task_id)},
         }
         with self._request("/rpc", request) as response:
             payload = json.loads(response.read().decode("utf-8"))

--- a/src/hermes_a2a/mapping.py
+++ b/src/hermes_a2a/mapping.py
@@ -2,71 +2,94 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from typing import Iterable
+from uuid import uuid4
 
 from .adapter import HermesEvent
 from .config import A2APluginConfig
+from .protocol import (
+    PROTOCOL_VERSION,
+    TASK_STATE_SUBMITTED,
+    normalize_task_state,
+)
 
 
 def utc_timestamp() -> str:
     """Return an RFC3339 timestamp in UTC."""
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
-def extract_text_from_message(message: dict | str | None) -> str:
-    """Extract text from the A2A message variants this bridge accepts.
-
-    The official path is text parts, but this helper also accepts a few loose
-    shapes so tool callers and older tests can share the same adapter boundary.
-    Keep any compatibility expansion here instead of spreading message parsing
-    through the service or adapter layers.
-    """
-    if message is None:
-        return ""
-    if isinstance(message, str):
-        return message
+def extract_text_from_message(message: dict | None) -> str:
+    """Extract text from an official A2A Message object."""
     if not isinstance(message, dict):
-        return str(message)
-
-    if "text" in message and isinstance(message["text"], str):
-        return message["text"]
-
+        raise ValueError("SendMessageRequest.message is required")
     parts = message.get("parts")
-    if isinstance(parts, list):
-        texts: list[str] = []
-        for part in parts:
-            if not isinstance(part, dict):
-                continue
-            if part.get("type") == "text" and isinstance(part.get("text"), str):
-                texts.append(part["text"])
-                continue
-            root = part.get("root")
-            if isinstance(root, dict):
-                if root.get("kind") == "text" and isinstance(root.get("text"), str):
-                    texts.append(root["text"])
-                elif root.get("type") == "text" and isinstance(root.get("text"), str):
-                    texts.append(root["text"])
-        if texts:
-            return "\n".join(texts)
-
-    metadata = message.get("metadata")
-    if isinstance(metadata, dict) and isinstance(metadata.get("text"), str):
-        return metadata["text"]
-
-    return ""
+    if not isinstance(parts, list) or not parts:
+        raise ValueError("Message.parts must contain at least one part")
+    texts: list[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            raise ValueError("Message.parts entries must be objects")
+        if isinstance(part.get("text"), str):
+            texts.append(part["text"])
+            continue
+        if isinstance(part.get("data"), dict):
+            data_part = part["data"]
+            data = data_part.get("data") if isinstance(data_part.get("data"), dict) else data_part
+            texts.append(json.dumps(data, sort_keys=True))
+            continue
+        if isinstance(part.get("file"), dict):
+            file_part = part["file"]
+            file_ref = file_part.get("fileWithUri") or file_part.get("fileWithBytes")
+            if not file_ref:
+                raise ValueError("File parts must include fileWithUri or fileWithBytes")
+            details = [str(file_ref)]
+            if file_part.get("name"):
+                details.append(f"name={file_part['name']}")
+            if file_part.get("mediaType"):
+                details.append(f"mediaType={file_part['mediaType']}")
+            texts.append("file: " + " ".join(details))
+            continue
+        raise ValueError("Message.parts entries must contain text, data, or file")
+    if not texts:
+        raise ValueError("Message.parts must contain text, data, or file content")
+    return "\n".join(texts)
 
 
 def build_text_part(text: str) -> dict:
-    return {"type": "text", "text": text}
+    return {"text": text}
 
 
 def build_data_part(data: dict) -> dict:
-    return {"type": "data", "data": data}
+    return {"data": {"data": data}}
 
 
 def build_file_part(uri: str) -> dict:
-    return {"type": "file", "uri": uri}
+    return {"file": {"fileWithUri": uri}}
+
+
+def build_message(
+    role: str,
+    parts: list[dict],
+    message_id: str | None = None,
+    task_id: str = "",
+    context_id: str = "",
+    metadata: dict | None = None,
+) -> dict:
+    message = {
+        "messageId": message_id or str(uuid4()),
+        "role": role,
+        "parts": parts,
+    }
+    if context_id:
+        message["contextId"] = context_id
+    if task_id:
+        message["taskId"] = task_id
+    if metadata:
+        message["metadata"] = metadata
+    return message
 
 
 def build_artifact_from_event(event: HermesEvent) -> dict | None:
@@ -90,37 +113,32 @@ def build_artifact_from_event(event: HermesEvent) -> dict | None:
 def build_initial_task(
     task_id: str,
     context_id: str,
-    message_text: str,
+    message: dict,
     direction: str,
     metadata: dict | None = None,
 ) -> dict:
     """Create the task snapshot before any runtime event has been applied."""
     timestamp = utc_timestamp()
+    user_message = dict(message)
+    user_message.setdefault("messageId", str(uuid4()))
+    user_message.setdefault("role", "ROLE_USER")
+    user_message["taskId"] = task_id
+    user_message["contextId"] = context_id
     return {
-        "kind": "task",
         "id": task_id,
         "contextId": context_id,
-        "direction": direction,
-        "historyLength": 1,
-        "createdAt": timestamp,
-        "updatedAt": timestamp,
-        "messages": [
-            {
-                "role": "user",
-                "parts": [build_text_part(message_text)],
-                "timestamp": timestamp,
-            }
-        ],
-        "artifacts": [],
         "metadata": metadata or {},
+        "artifacts": [],
+        "history": [user_message],
         "status": {
-            "state": "submitted",
+            "state": TASK_STATE_SUBMITTED,
             "timestamp": timestamp,
-            "message": {
-                "role": "agent",
-                "parts": [build_text_part("Task submitted")],
-                "timestamp": timestamp,
-            },
+            "message": build_message(
+                "ROLE_AGENT",
+                [build_text_part("Task submitted")],
+                task_id=task_id,
+                context_id=context_id,
+            ),
         },
     }
 
@@ -133,30 +151,32 @@ def apply_hermes_event(task: dict, event: HermesEvent) -> dict:
     task snapshots and event names.
     """
     timestamp = utc_timestamp()
-    task["updatedAt"] = timestamp
-    task["historyLength"] = int(task.get("historyLength", 0)) + 1
 
     if event.kind in {"status", "requires_input"}:
-        # Status events mutate the task's terminal state and are also appended
-        # to message history so resumed clients can reconstruct the exchange.
+        state = normalize_task_state(event.state)
+        message = build_message(
+            "ROLE_AGENT",
+            [build_text_part(event.message or state)],
+            task_id=task["id"],
+            context_id=task["contextId"],
+        )
         task["status"] = {
-            "state": event.state,
+            "state": state,
             "timestamp": timestamp,
-            "message": {
-                "role": "agent",
-                "parts": [build_text_part(event.message or event.state)],
-                "timestamp": timestamp,
-            },
+            "message": message,
         }
-        task.setdefault("messages", []).append(task["status"]["message"])
+        task.setdefault("history", []).append(message)
         return {
-            "event": "task_status_update",
-            "data": {
+            "statusUpdate": {
                 "taskId": task["id"],
                 "contextId": task["contextId"],
-                "state": event.state,
-                "message": event.message or event.state,
-                "timestamp": timestamp,
+                "status": task["status"],
+                "final": state in {
+                    "TASK_STATE_COMPLETED",
+                    "TASK_STATE_FAILED",
+                    "TASK_STATE_CANCELLED",
+                    "TASK_STATE_REJECTED",
+                },
             },
         }
 
@@ -164,23 +184,16 @@ def apply_hermes_event(task: dict, event: HermesEvent) -> dict:
     if artifact is not None:
         task.setdefault("artifacts", []).append(artifact)
         return {
-            "event": "task_artifact_update",
-            "data": {
+            "artifactUpdate": {
                 "taskId": task["id"],
                 "contextId": task["contextId"],
                 "artifact": artifact,
-                "timestamp": timestamp,
+                "append": False,
+                "lastChunk": True,
             },
         }
 
-    return {
-        "event": "task_update",
-        "data": {
-            "taskId": task["id"],
-            "contextId": task["contextId"],
-            "timestamp": timestamp,
-        },
-    }
+    return {"task": task}
 
 
 def build_agent_card(config: A2APluginConfig) -> dict:
@@ -191,18 +204,27 @@ def build_agent_card(config: A2APluginConfig) -> dict:
             "name": skill.replace("-", " ").title(),
             "description": f"Explicitly exported Hermes skill: {skill}",
             "tags": ["hermes", "a2a"],
+            "inputModes": ["text/plain", "application/json"],
+            "outputModes": ["text/plain", "application/json"],
         }
         for skill in config.exported_skills
     ]
     card = {
         "name": "Hermes A2A Plugin",
         "description": "Hermes exposed as a bidirectional A2A bridge.",
-        "url": config.rpc_url,
-        "provider": {"organization": "Hermes"},
+        "protocolVersions": [PROTOCOL_VERSION],
+        "supportedInterfaces": [
+            {
+                "url": config.rpc_url,
+                "protocolBinding": "JSONRPC",
+            }
+        ],
+        "provider": {
+            "organization": "Hermes",
+            "url": config.resolved_public_base_url,
+        },
         "version": config.version,
         "documentationUrl": config.card_url,
-        "preferredTransport": "JSONRPC",
-        "protocolVersion": "1.0",
         "defaultInputModes": ["text/plain", "application/json"],
         "defaultOutputModes": ["text/plain", "application/json"],
         "capabilities": {
@@ -212,18 +234,40 @@ def build_agent_card(config: A2APluginConfig) -> dict:
         "skills": skills,
     }
     if config.bearer_token:
-        card["security"] = [{"type": "bearer", "scheme": "Bearer"}]
+        card["securitySchemes"] = {
+            "bearerAuth": {
+                "httpAuthSecurityScheme": {
+                    "scheme": "Bearer",
+                }
+            }
+        }
+        card["security"] = [{"schemes": {"bearerAuth": {"list": []}}}]
     return card
 
 
-def make_sse_payload(event_name: str, data: dict) -> bytes:
-    """Encode one A2A task update as a Server-Sent Event frame."""
+def make_sse_payload(payload: dict) -> bytes:
+    """Encode one A2A JSON-RPC stream response as an SSE frame."""
     import json
 
-    return (
-        f"event: {event_name}\n"
-        f"data: {json.dumps(data, sort_keys=True)}\n\n"
-    ).encode("utf-8")
+    return f"data: {json.dumps(payload, sort_keys=True)}\n\n".encode("utf-8")
+
+
+def trim_task_for_response(task: dict, history_length: int | None = None, include_artifacts: bool = True) -> dict:
+    """Return a task copy with response-level history/artifact constraints applied."""
+    result = json_clone(task)
+    if history_length is not None:
+        if history_length < 0:
+            raise ValueError("historyLength must be non-negative")
+        result["history"] = result.get("history", [])[-history_length:] if history_length else []
+    if not include_artifacts:
+        result.pop("artifacts", None)
+    return result
+
+
+def json_clone(value: dict) -> dict:
+    import json
+
+    return json.loads(json.dumps(value))
 
 
 def summarize_agents(agents: Iterable[dict]) -> list[dict]:

--- a/src/hermes_a2a/protocol.py
+++ b/src/hermes_a2a/protocol.py
@@ -1,0 +1,175 @@
+"""A2A 1.0 protocol constants and small wire-shape helpers."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+PROTOCOL_VERSION = "1.0"
+RPC_PATH = "/rpc"
+A2A_CONTENT_TYPE = "application/a2a+json"
+
+METHOD_SEND_MESSAGE = "SendMessage"
+METHOD_SEND_STREAMING_MESSAGE = "SendStreamingMessage"
+METHOD_GET_TASK = "GetTask"
+METHOD_LIST_TASKS = "ListTasks"
+METHOD_CANCEL_TASK = "CancelTask"
+METHOD_SUBSCRIBE_TO_TASK = "SubscribeToTask"
+METHOD_CREATE_PUSH_CONFIG = "CreateTaskPushNotificationConfig"
+METHOD_GET_PUSH_CONFIG = "GetTaskPushNotificationConfig"
+METHOD_LIST_PUSH_CONFIGS = "ListTaskPushNotificationConfig"
+METHOD_DELETE_PUSH_CONFIG = "DeleteTaskPushNotificationConfig"
+METHOD_GET_EXTENDED_AGENT_CARD = "GetExtendedAgentCard"
+
+TASK_STATE_SUBMITTED = "TASK_STATE_SUBMITTED"
+TASK_STATE_WORKING = "TASK_STATE_WORKING"
+TASK_STATE_COMPLETED = "TASK_STATE_COMPLETED"
+TASK_STATE_FAILED = "TASK_STATE_FAILED"
+TASK_STATE_CANCELLED = "TASK_STATE_CANCELLED"
+TASK_STATE_INPUT_REQUIRED = "TASK_STATE_INPUT_REQUIRED"
+TASK_STATE_REJECTED = "TASK_STATE_REJECTED"
+TASK_STATE_AUTH_REQUIRED = "TASK_STATE_AUTH_REQUIRED"
+
+TERMINAL_TASK_STATES = {
+    TASK_STATE_COMPLETED,
+    TASK_STATE_FAILED,
+    TASK_STATE_CANCELLED,
+    TASK_STATE_REJECTED,
+}
+
+ERROR_PARSE = -32700
+ERROR_METHOD_NOT_FOUND = -32601
+ERROR_INVALID_PARAMS = -32602
+ERROR_INTERNAL = -32603
+ERROR_TASK_NOT_FOUND = -32001
+ERROR_UNSUPPORTED_OPERATION = -32004
+ERROR_VERSION_NOT_SUPPORTED = -32009
+
+STATE_MAP = {
+    "submitted": TASK_STATE_SUBMITTED,
+    "working": TASK_STATE_WORKING,
+    "completed": TASK_STATE_COMPLETED,
+    "failed": TASK_STATE_FAILED,
+    "cancelled": TASK_STATE_CANCELLED,
+    "canceled": TASK_STATE_CANCELLED,
+    "input-required": TASK_STATE_INPUT_REQUIRED,
+    "input_required": TASK_STATE_INPUT_REQUIRED,
+    "requires-input": TASK_STATE_INPUT_REQUIRED,
+    "rejected": TASK_STATE_REJECTED,
+    "auth-required": TASK_STATE_AUTH_REQUIRED,
+}
+
+
+@dataclass(slots=True)
+class A2AProtocolError(Exception):
+    """Exception carrying an A2A JSON-RPC error code."""
+
+    code: int
+    message: str
+
+
+def normalize_task_state(state: str) -> str:
+    if state.startswith("TASK_STATE_"):
+        return state
+    return STATE_MAP.get(state.strip().lower(), TASK_STATE_WORKING)
+
+
+def jsonrpc_success(request_id, result: dict | list | None) -> dict:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def jsonrpc_error(request_id, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def task_name(task_id: str) -> str:
+    return f"tasks/{task_id}"
+
+
+def parse_task_name(name: str) -> str:
+    value = str(name or "").strip()
+    prefix = "tasks/"
+    if not value.startswith(prefix) or "/" in value[len(prefix):] or not value[len(prefix):]:
+        raise ValueError("Expected task resource name in format tasks/{task_id}")
+    return value[len(prefix):]
+
+
+def push_config_name(task_id: str, config_id: str) -> str:
+    return f"tasks/{task_id}/pushNotificationConfigs/{config_id}"
+
+
+def parse_push_config_name(name: str) -> tuple[str, str]:
+    value = str(name or "").strip()
+    parts = value.split("/")
+    if len(parts) != 4 or parts[0] != "tasks" or parts[2] != "pushNotificationConfigs":
+        raise ValueError(
+            "Expected push config resource name in format "
+            "tasks/{task_id}/pushNotificationConfigs/{config_id}"
+        )
+    if not parts[1] or not parts[3]:
+        raise ValueError(
+            "Expected push config resource name in format "
+            "tasks/{task_id}/pushNotificationConfigs/{config_id}"
+        )
+    return parts[1], parts[3]
+
+
+def encode_page_token(offset: int) -> str:
+    if offset <= 0:
+        return ""
+    raw = json.dumps({"offset": offset}, sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def decode_page_token(token: str) -> int:
+    if not token:
+        return 0
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        decoded = json.loads(raw.decode("utf-8"))
+        return max(0, int(decoded.get("offset", 0)))
+    except Exception as exc:
+        raise ValueError("Invalid pageToken") from exc
+
+
+def encode_task_page_token(task: dict) -> str:
+    raw = json.dumps(
+        {
+            "statusTimestamp": str(task.get("status", {}).get("timestamp", "")),
+            "id": str(task.get("id", "")),
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def decode_task_page_token(token: str) -> dict:
+    if not token:
+        return {}
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("ascii"))
+        decoded = json.loads(raw.decode("utf-8"))
+        return {
+            "statusTimestamp": str(decoded.get("statusTimestamp", "")),
+            "id": str(decoded.get("id", "")),
+        }
+    except Exception as exc:
+        raise ValueError("Invalid pageToken") from exc
+
+
+def parse_rfc3339_timestamp(value: str) -> datetime:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("Timestamp is required")
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError("Invalid RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -9,7 +9,7 @@ from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Iterable
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 from uuid import uuid4
 
 from .adapter import (
@@ -24,12 +24,43 @@ from .mapping import (
     build_initial_task,
     extract_text_from_message,
     make_sse_payload,
+    trim_task_for_response,
+)
+from .protocol import (
+    A2A_CONTENT_TYPE,
+    A2AProtocolError,
+    ERROR_INTERNAL,
+    ERROR_INVALID_PARAMS,
+    ERROR_METHOD_NOT_FOUND,
+    ERROR_PARSE,
+    ERROR_TASK_NOT_FOUND,
+    ERROR_UNSUPPORTED_OPERATION,
+    ERROR_VERSION_NOT_SUPPORTED,
+    METHOD_CANCEL_TASK,
+    METHOD_CREATE_PUSH_CONFIG,
+    METHOD_DELETE_PUSH_CONFIG,
+    METHOD_GET_EXTENDED_AGENT_CARD,
+    METHOD_GET_PUSH_CONFIG,
+    METHOD_GET_TASK,
+    METHOD_LIST_PUSH_CONFIGS,
+    METHOD_LIST_TASKS,
+    METHOD_SEND_MESSAGE,
+    METHOD_SEND_STREAMING_MESSAGE,
+    METHOD_SUBSCRIBE_TO_TASK,
+    PROTOCOL_VERSION,
+    TERMINAL_TASK_STATES,
+    decode_page_token,
+    decode_task_page_token,
+    encode_page_token,
+    encode_task_page_token,
+    jsonrpc_error,
+    jsonrpc_success,
+    parse_push_config_name,
+    parse_rfc3339_timestamp,
+    parse_task_name,
+    push_config_name,
 )
 from .store import SQLiteTaskStore
-
-
-def _jsonrpc_error(request_id, code: int, message: str) -> dict:
-    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
 
 
 def _build_execution_adapter(config: A2APluginConfig) -> HermesExecutionAdapter:
@@ -97,38 +128,59 @@ class A2AService:
             return self.adapter.stream(task_id, context_id, message_text, metadata) if stream else self.adapter.start(task_id, context_id, message_text, metadata)
         return self.adapter.stream(task_id, context_id, message_text, metadata) if stream else self.adapter.continue_task(task_id, context_id, message_text, metadata)
 
-    def _notify_push(self, task_id: str, event_name: str, data: dict) -> None:
-        config = self.store.get_push_config(task_id)
-        if not config:
-            return
-        push_config = config["pushNotificationConfig"]
-        payload = json.dumps({"event": event_name, "data": data}).encode("utf-8")
-        headers = {"Content-Type": "application/json"}
-        token = push_config.get("token", "")
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        request = urllib.request.Request(
-            push_config["url"],
-            data=payload,
-            headers=headers,
-        )
-        try:
-            urllib.request.urlopen(request, timeout=self.config.default_timeout_seconds).read()
-        except Exception:
-            # Push delivery is best-effort. The event remains durable in SQLite.
-            return
+    def _notify_push(self, task_id: str, stream_response: dict) -> None:
+        for config in self.store.list_push_configs_for_task(task_id):
+            push_config = config["pushNotificationConfig"]
+            payload = json.dumps(stream_response, sort_keys=True).encode("utf-8")
+            headers = {"Content-Type": A2A_CONTENT_TYPE}
+            auth = push_config.get("authentication") or {}
+            schemes = [str(scheme).lower() for scheme in auth.get("schemes", [])]
+            credentials = str(auth.get("credentials", "")).strip()
+            if credentials and "bearer" in schemes:
+                headers["Authorization"] = f"Bearer {credentials}"
+            elif credentials and schemes:
+                headers["Authorization"] = f"{schemes[0]} {credentials}"
+            request = urllib.request.Request(
+                push_config["url"],
+                data=payload,
+                headers=headers,
+            )
+            try:
+                urllib.request.urlopen(request, timeout=self.config.default_timeout_seconds).read()
+            except Exception:
+                # Push delivery is best-effort. The event remains durable in SQLite.
+                continue
 
     def send_message(
         self,
         params: dict,
         stream: bool = False,
     ) -> tuple[dict, list[dict]]:
-        task_id = str(params.get("taskId") or uuid4())
-        context_id = str(params.get("contextId") or task_id)
-        message_text = extract_text_from_message(params.get("message"))
+        message = params.get("message")
+        message_text = extract_text_from_message(message)
+        if not isinstance(message, dict):
+            raise ValueError("SendMessageRequest.message is required")
+        if not message.get("messageId"):
+            raise ValueError("Message.messageId is required")
+        if message.get("role") != "ROLE_USER":
+            raise ValueError("Message.role must be ROLE_USER")
+        task_id = str(message.get("taskId") or uuid4())
         task = self.store.get_task(task_id)
+        context_id = str(
+            task.get("contextId")
+            if task is not None
+            else message.get("contextId") or task_id
+        )
+        if message.get("contextId") and str(message["contextId"]) != context_id:
+            raise ValueError("Message.contextId must match the task context")
+        message = dict(message)
+        message["taskId"] = task_id
+        message["contextId"] = context_id
         if task is None:
-            task = build_initial_task(task_id, context_id, message_text, direction="inbound")
+            task = build_initial_task(task_id, context_id, message, direction="inbound")
+        else:
+            task.setdefault("history", []).append(message)
+        self._configure_push_from_send_message(task_id, params.get("configuration") or {})
         events: list[dict] = []
 
         # Persist each mapped event before push delivery. If a callback fails,
@@ -140,15 +192,42 @@ class A2AService:
             stream=stream,
             metadata={"mode": "stream" if stream else "send"},
         ):
-            envelope = apply_hermes_event(task, adapter_event)
-            seq = self.store.append_event(task_id, envelope["event"], envelope["data"])
-            envelope["data"]["sequence"] = seq
-            events.append(envelope)
-            self._notify_push(task_id, envelope["event"], envelope["data"])
+            stream_response = apply_hermes_event(task, adapter_event)
+            self.store.append_event(task_id, stream_response)
+            events.append(stream_response)
+            self._notify_push(task_id, stream_response)
 
-        task.setdefault("metadata", {}).update(self.adapter.finalize_task(task_id, context_id))
+        adapter_metadata = self.adapter.finalize_task(task_id, context_id)
+        task.setdefault("metadata", {}).update(
+            {
+                "adapter": adapter_metadata.get("adapter", "unknown"),
+                "adapterMetadata": adapter_metadata.get("metadata", {}),
+            }
+        )
         self.store.upsert_task(task, direction="inbound")
         return task, events
+
+    def _configure_push_from_send_message(self, task_id: str, configuration: dict) -> None:
+        if not isinstance(configuration, dict):
+            raise ValueError("SendMessageRequest.configuration must be an object")
+        push_config = configuration.get("pushNotificationConfig")
+        if push_config is None:
+            return
+        if not isinstance(push_config, dict):
+            raise ValueError("configuration.pushNotificationConfig must be an object")
+        if not str(push_config.get("url", "")).strip():
+            raise ValueError("pushNotificationConfig.url is required")
+        config_id = str(push_config.get("id") or uuid4()).strip()
+        stored_push_config = dict(push_config)
+        stored_push_config["id"] = config_id
+        self.store.set_push_config(
+            task_id,
+            config_id,
+            {
+                "name": push_config_name(task_id, config_id),
+                "pushNotificationConfig": stored_push_config,
+            },
+        )
 
     def get_task(self, task_id: str) -> dict:
         task = self.store.get_task(task_id)
@@ -160,41 +239,135 @@ class A2AService:
         task = self.get_task(task_id)
         context_id = task.get("contextId", task_id)
         for adapter_event in self.adapter.cancel(task_id, context_id):
-            envelope = apply_hermes_event(task, adapter_event)
-            seq = self.store.append_event(task_id, envelope["event"], envelope["data"])
-            envelope["data"]["sequence"] = seq
-            self._notify_push(task_id, envelope["event"], envelope["data"])
-        self.store.upsert_task(task, direction=task.get("direction", "inbound"))
+            stream_response = apply_hermes_event(task, adapter_event)
+            self.store.append_event(task_id, stream_response)
+            self._notify_push(task_id, stream_response)
+        self.store.upsert_task(task, direction="inbound")
         return task
 
-    def resubscribe(self, task_id: str, after_seq: int = 0) -> list[dict]:
-        return self.store.list_events(task_id, after_seq=after_seq)
+    def subscribe_task(self, task_id: str) -> list[dict]:
+        task = self.get_task(task_id)
+        state = task.get("status", {}).get("state", "")
+        if state in TERMINAL_TASK_STATES:
+            raise A2AProtocolError(
+                ERROR_UNSUPPORTED_OPERATION,
+                "SubscribeToTask is not supported for terminal tasks",
+            )
+        return [{"task": task}, *self.store.list_events(task_id)]
 
-    def set_push_config(self, params: dict) -> dict:
-        task_id = str(params.get("id") or params.get("taskId") or "").strip()
-        if not task_id:
-            raise ValueError("Missing task id")
-        config = params.get("pushNotificationConfig") or {}
-        url = str(config.get("url", "")).strip()
-        token = str(config.get("token", "")).strip()
-        if not url:
-            raise ValueError("Missing push notification url")
-        return self.store.set_push_config(task_id, url, token)
+    def list_tasks(self, params: dict) -> dict:
+        page_size = int(params.get("pageSize") or 50)
+        if page_size < 1 or page_size > 100:
+            raise ValueError("pageSize must be between 1 and 100")
+        cursor = decode_task_page_token(str(params.get("pageToken") or ""))
+        context_id = str(params.get("contextId") or "")
+        status = str(params.get("status") or "")
+        status_after = params.get("statusTimestampAfter")
+        history_length = params.get("historyLength")
+        history_limit = int(history_length) if history_length is not None else None
+        include_artifacts = bool(params.get("includeArtifacts", False))
+        tasks = self.store.list_tasks()
+        if context_id:
+            tasks = [task for task in tasks if task.get("contextId") == context_id]
+        if status:
+            tasks = [task for task in tasks if task.get("status", {}).get("state") == status]
+        if status_after:
+            status_after_time = parse_rfc3339_timestamp(str(status_after))
+            tasks = [
+                task
+                for task in tasks
+                if parse_rfc3339_timestamp(str(task.get("status", {}).get("timestamp", "")))
+                >= status_after_time
+            ]
+        tasks.sort(
+            key=lambda task: (
+                str(task.get("status", {}).get("timestamp", "")),
+                str(task.get("id", "")),
+            ),
+            reverse=True,
+        )
+        total_size = len(tasks)
+        if cursor:
+            cursor_key = (cursor["statusTimestamp"], cursor["id"])
+            tasks = [
+                task
+                for task in tasks
+                if (
+                    str(task.get("status", {}).get("timestamp", "")),
+                    str(task.get("id", "")),
+                )
+                < cursor_key
+            ]
+        page = tasks[:page_size]
+        return {
+            "tasks": [
+                trim_task_for_response(task, history_limit, include_artifacts=include_artifacts)
+                for task in page
+            ],
+            "nextPageToken": encode_task_page_token(page[-1]) if len(tasks) > page_size else "",
+            "pageSize": page_size,
+            "totalSize": total_size,
+        }
 
-    def get_push_config(self, params: dict) -> dict | None:
-        task_id = str(params.get("id") or params.get("taskId") or "").strip()
-        if not task_id:
-            raise ValueError("Missing task id")
-        return self.store.get_push_config(task_id)
+    def create_push_config(self, params: dict) -> dict:
+        task_id = parse_task_name(str(params.get("parent") or ""))
+        self.get_task(task_id)
+        config_id = str(params.get("configId") or "").strip()
+        if not config_id:
+            raise ValueError("configId is required")
+        config = params.get("config") or {}
+        push_config = config.get("pushNotificationConfig") if isinstance(config, dict) else None
+        if not isinstance(push_config, dict):
+            raise ValueError("config.pushNotificationConfig is required")
+        if not str(push_config.get("url", "")).strip():
+            raise ValueError("pushNotificationConfig.url is required")
+        return self.store.set_push_config(
+            task_id,
+            config_id,
+            {
+                "name": push_config_name(task_id, config_id),
+                "pushNotificationConfig": push_config,
+            },
+        )
 
-    def list_push_configs(self) -> list[dict]:
-        return self.store.list_push_configs()
+    def get_push_config(self, params: dict) -> dict:
+        name = str(params.get("name") or "")
+        parse_push_config_name(name)
+        result = self.store.get_push_config(name)
+        if result is None:
+            raise KeyError(name)
+        return result
+
+    def list_push_configs(self, params: dict) -> dict:
+        task_id = parse_task_name(str(params.get("parent") or ""))
+        self.get_task(task_id)
+        page_size = int(params.get("pageSize") or 50)
+        if page_size < 1 or page_size > 100:
+            raise ValueError("pageSize must be between 1 and 100")
+        offset = decode_page_token(str(params.get("pageToken") or ""))
+        configs = self.store.list_push_configs(task_id)
+        page = configs[offset : offset + page_size]
+        next_offset = offset + page_size
+        return {
+            "configs": page,
+            "nextPageToken": encode_page_token(next_offset) if next_offset < len(configs) else "",
+        }
 
     def delete_push_config(self, params: dict) -> None:
-        task_id = str(params.get("id") or params.get("taskId") or "").strip()
-        if not task_id:
-            raise ValueError("Missing task id")
-        self.store.delete_push_config(task_id)
+        name = str(params.get("name") or "")
+        parse_push_config_name(name)
+        if self.store.get_push_config(name) is None:
+            raise KeyError(name)
+        self.store.delete_push_config(name)
+
+    def extended_agent_card(self) -> dict:
+        card = self.agent_card()
+        if card.get("capabilities", {}).get("extendedAgentCard") is not True:
+            raise A2AProtocolError(
+                ERROR_UNSUPPORTED_OPERATION,
+                "Extended agent card is not supported",
+            )
+        return card
 
     def close(self) -> None:
         self.store.close()
@@ -227,6 +400,15 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_stream(self, request_id, stream_responses: Iterable[dict]) -> None:
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        for stream_response in stream_responses:
+            self.wfile.write(make_sse_payload(jsonrpc_success(request_id, stream_response)))
+            self.wfile.flush()
+
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         parsed = urlparse(self.path)
         if parsed.path == "/.well-known/agent-card.json":
@@ -237,19 +419,6 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
         if not self._require_auth():
             self._send_json({"error": "Unauthorized"}, status=HTTPStatus.UNAUTHORIZED)
-            return
-
-        if parsed.path.startswith("/tasks/") and parsed.path.endswith("/events"):
-            task_id = parsed.path.split("/")[2]
-            after_seq = int(parse_qs(parsed.query).get("after_seq", ["0"])[0])
-            events = self._service.resubscribe(task_id, after_seq=after_seq)
-            self.send_response(HTTPStatus.OK)
-            self.send_header("Content-Type", "text/event-stream")
-            self.send_header("Cache-Control", "no-cache")
-            self.end_headers()
-            for event in events:
-                self.wfile.write(make_sse_payload(event["event"], event["data"]))
-                self.wfile.flush()
             return
 
         self._send_json({"error": "Not found"}, status=HTTPStatus.NOT_FOUND)
@@ -265,90 +434,96 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
         content_length = int(self.headers.get("Content-Length", "0"))
         request_bytes = self.rfile.read(content_length)
-        request = json.loads(request_bytes.decode("utf-8"))
+        try:
+            request = json.loads(request_bytes.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._send_json(jsonrpc_error(None, ERROR_PARSE, "Invalid JSON payload"))
+            return
         request_id = request.get("id")
         method = request.get("method")
         params = request.get("params") or {}
+        if self.headers.get("A2A-Version", "") != PROTOCOL_VERSION:
+            self._send_json(
+                jsonrpc_error(
+                    request_id,
+                    ERROR_VERSION_NOT_SUPPORTED,
+                    "A2A-Version header must be 1.0",
+                )
+            )
+            return
 
         try:
-            if method == "message/send":
+            if method == METHOD_SEND_MESSAGE:
                 task, _ = self._service.send_message(params, stream=False)
-                self._send_json({"jsonrpc": "2.0", "id": request_id, "result": task})
+                history_length = (params.get("configuration") or {}).get("historyLength")
+                result = {
+                    "task": trim_task_for_response(
+                        task,
+                        int(history_length) if history_length is not None else None,
+                    )
+                }
+                self._send_json(jsonrpc_success(request_id, result))
                 return
 
-            if method == "message/stream":
+            if method == METHOD_SEND_STREAMING_MESSAGE:
                 task, events = self._service.send_message(params, stream=True)
-                # This implementation buffers adapter output, then emits a
-                # compact SSE replay plus a final task snapshot for clients.
-                self.send_response(HTTPStatus.OK)
-                self.send_header("Content-Type", "text/event-stream")
-                self.send_header("Cache-Control", "no-cache")
-                self.end_headers()
-                for event in events:
-                    self.wfile.write(make_sse_payload(event["event"], event["data"]))
-                    self.wfile.flush()
-                self.wfile.write(make_sse_payload("task", task))
-                self.wfile.flush()
+                self._send_stream(request_id, [*events, {"task": task}])
                 return
 
-            if method == "tasks/get":
-                task_id = str(params.get("id") or "")
-                self._send_json(
-                    {"jsonrpc": "2.0", "id": request_id, "result": self._service.get_task(task_id)}
+            if method == METHOD_GET_TASK:
+                task_id = parse_task_name(str(params.get("name") or ""))
+                history_length = params.get("historyLength")
+                task = trim_task_for_response(
+                    self._service.get_task(task_id),
+                    int(history_length) if history_length is not None else None,
                 )
+                self._send_json(jsonrpc_success(request_id, task))
                 return
 
-            if method == "tasks/cancel":
-                task_id = str(params.get("id") or "")
-                self._send_json(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": request_id,
-                        "result": self._service.cancel_task(task_id),
-                    }
-                )
+            if method == METHOD_LIST_TASKS:
+                self._send_json(jsonrpc_success(request_id, self._service.list_tasks(params)))
                 return
 
-            if method == "tasks/resubscribe":
-                task_id = str(params.get("id") or "")
-                after_seq = int(params.get("afterSeq", 0))
-                events = self._service.resubscribe(task_id, after_seq=after_seq)
-                self.send_response(HTTPStatus.OK)
-                self.send_header("Content-Type", "text/event-stream")
-                self.send_header("Cache-Control", "no-cache")
-                self.end_headers()
-                for event in events:
-                    self.wfile.write(make_sse_payload(event["event"], event["data"]))
-                    self.wfile.flush()
+            if method == METHOD_CANCEL_TASK:
+                task_id = parse_task_name(str(params.get("name") or ""))
+                self._send_json(jsonrpc_success(request_id, self._service.cancel_task(task_id)))
                 return
 
-            if method == "tasks/pushNotificationConfig/set":
-                result = self._service.set_push_config(params)
-                self._send_json({"jsonrpc": "2.0", "id": request_id, "result": result})
+            if method == METHOD_SUBSCRIBE_TO_TASK:
+                task_id = parse_task_name(str(params.get("name") or ""))
+                self._send_stream(request_id, self._service.subscribe_task(task_id))
                 return
 
-            if method == "tasks/pushNotificationConfig/get":
-                result = self._service.get_push_config(params)
-                self._send_json({"jsonrpc": "2.0", "id": request_id, "result": result})
+            if method == METHOD_CREATE_PUSH_CONFIG:
+                self._send_json(jsonrpc_success(request_id, self._service.create_push_config(params)))
                 return
 
-            if method == "tasks/pushNotificationConfig/list":
-                result = self._service.list_push_configs()
-                self._send_json({"jsonrpc": "2.0", "id": request_id, "result": result})
+            if method == METHOD_GET_PUSH_CONFIG:
+                self._send_json(jsonrpc_success(request_id, self._service.get_push_config(params)))
                 return
 
-            if method == "tasks/pushNotificationConfig/delete":
+            if method == METHOD_LIST_PUSH_CONFIGS:
+                self._send_json(jsonrpc_success(request_id, self._service.list_push_configs(params)))
+                return
+
+            if method == METHOD_DELETE_PUSH_CONFIG:
                 self._service.delete_push_config(params)
-                self._send_json({"jsonrpc": "2.0", "id": request_id, "result": None})
+                self._send_json(jsonrpc_success(request_id, None))
                 return
 
-            self._send_json(_jsonrpc_error(request_id, -32601, f"Unknown method: {method}"))
+            if method == METHOD_GET_EXTENDED_AGENT_CARD:
+                self._send_json(jsonrpc_success(request_id, self._service.extended_agent_card()))
+                return
+
+            self._send_json(jsonrpc_error(request_id, ERROR_METHOD_NOT_FOUND, f"Unknown method: {method}"))
+        except A2AProtocolError as exc:
+            self._send_json(jsonrpc_error(request_id, exc.code, exc.message))
         except KeyError as exc:
-            self._send_json(_jsonrpc_error(request_id, -32004, f"Task not found: {exc.args[0]}"))
+            self._send_json(jsonrpc_error(request_id, ERROR_TASK_NOT_FOUND, f"Task not found: {exc.args[0]}"))
         except ValueError as exc:
-            self._send_json(_jsonrpc_error(request_id, -32602, str(exc)))
+            self._send_json(jsonrpc_error(request_id, ERROR_INVALID_PARAMS, str(exc)))
         except Exception as exc:  # pragma: no cover - defensive path
-            self._send_json(_jsonrpc_error(request_id, -32000, str(exc)))
+            self._send_json(jsonrpc_error(request_id, ERROR_INTERNAL, str(exc)))
 
 
 class ManagedA2AServer:

--- a/src/hermes_a2a/store.py
+++ b/src/hermes_a2a/store.py
@@ -8,15 +8,16 @@ import threading
 from pathlib import Path
 
 from .mapping import utc_timestamp
+from .protocol import push_config_name
 
 
 class SQLiteTaskStore:
     """Persist protocol-facing state outside the transport layer.
 
-    Task snapshots are optimized for current `tasks/get` responses. The event
-    journal is kept separately so SSE resubscribe can replay updates, and remote
-    delegation mappings stay outside snapshots so local task IDs can remain the
-    lookup key for Hermes tools.
+    Task snapshots are optimized for official `GetTask` and `ListTasks`
+    responses. The event journal stores StreamResponse payloads for
+    `SubscribeToTask`, and remote delegation mappings stay outside snapshots so
+    local task IDs can remain the lookup key for Hermes tools.
     """
 
     def __init__(self, path: str) -> None:
@@ -50,9 +51,12 @@ class SQLiteTaskStore:
                 );
 
                 CREATE TABLE IF NOT EXISTS push_configs (
-                    task_id TEXT PRIMARY KEY,
+                    name TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    config_id TEXT NOT NULL,
                     url TEXT NOT NULL,
                     token TEXT,
+                    config_json TEXT NOT NULL,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 );
@@ -70,7 +74,7 @@ class SQLiteTaskStore:
     def upsert_task(self, task: dict, direction: str) -> None:
         with self._lock, self._conn:
             now = utc_timestamp()
-            created_at = task.get("createdAt", now)
+            created_at = task.get("status", {}).get("timestamp", now)
             self._conn.execute(
                 """
                 INSERT INTO tasks (task_id, direction, context_id, state, snapshot_json, created_at, updated_at)
@@ -86,7 +90,7 @@ class SQLiteTaskStore:
                     task["id"],
                     direction,
                     task.get("contextId", task["id"]),
-                    task.get("status", {}).get("state", "submitted"),
+                    task.get("status", {}).get("state", "TASK_STATE_SUBMITTED"),
                     json.dumps(task, sort_keys=True),
                     created_at,
                     now,
@@ -114,83 +118,89 @@ class SQLiteTaskStore:
             ).fetchall()
         return [json.loads(row["snapshot_json"]) for row in rows]
 
-    def append_event(self, task_id: str, event_type: str, payload: dict) -> int:
+    def append_event(self, task_id: str, payload: dict) -> int:
         with self._lock, self._conn:
             cursor = self._conn.execute(
                 """
                 INSERT INTO events (task_id, event_type, payload_json, created_at)
                 VALUES (?, ?, ?, ?)
                 """,
-                (task_id, event_type, json.dumps(payload, sort_keys=True), utc_timestamp()),
+                (task_id, next(iter(payload.keys()), "task"), json.dumps(payload, sort_keys=True), utc_timestamp()),
             )
             return int(cursor.lastrowid)
 
-    def list_events(self, task_id: str, after_seq: int = 0) -> list[dict]:
+    def list_events(self, task_id: str) -> list[dict]:
         rows = self._conn.execute(
             """
             SELECT seq, event_type, payload_json, created_at
             FROM events
-            WHERE task_id = ? AND seq > ?
+            WHERE task_id = ?
             ORDER BY seq ASC
             """,
-            (task_id, after_seq),
+            (task_id,),
         ).fetchall()
-        results: list[dict] = []
-        for row in rows:
-            payload = json.loads(row["payload_json"])
-            results.append(
-                {
-                    "sequence": row["seq"],
-                    "event": row["event_type"],
-                    "data": payload,
-                    "createdAt": row["created_at"],
-                }
-            )
-        return results
+        return [json.loads(row["payload_json"]) for row in rows]
 
-    def set_push_config(self, task_id: str, url: str, token: str = "") -> dict:
+    def set_push_config(
+        self,
+        task_id: str,
+        config_id: str,
+        config: dict,
+    ) -> dict:
         now = utc_timestamp()
+        name = push_config_name(task_id, config_id)
+        push_config = dict(config.get("pushNotificationConfig") or config)
+        push_config.setdefault("id", config_id)
+        push_config.setdefault("url", "")
+        push_config.setdefault("token", "")
+        stored = {"name": name, "pushNotificationConfig": push_config}
         with self._lock, self._conn:
             self._conn.execute(
                 """
-                INSERT INTO push_configs (task_id, url, token, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(task_id) DO UPDATE SET
+                INSERT INTO push_configs
+                    (name, task_id, config_id, url, token, config_json, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
                     url = excluded.url,
                     token = excluded.token,
+                    config_json = excluded.config_json,
                     updated_at = excluded.updated_at
                 """,
-                (task_id, url, token, now, now),
+                (
+                    name,
+                    task_id,
+                    config_id,
+                    str(push_config.get("url", "")),
+                    str(push_config.get("token", "")),
+                    json.dumps(stored, sort_keys=True),
+                    now,
+                    now,
+                ),
             )
-        return {"taskId": task_id, "pushNotificationConfig": {"url": url, "token": token}}
+        return stored
 
-    def get_push_config(self, task_id: str) -> dict | None:
+    def get_push_config(self, name: str) -> dict | None:
         row = self._conn.execute(
-            "SELECT task_id, url, token FROM push_configs WHERE task_id = ?",
-            (task_id,),
+            "SELECT config_json FROM push_configs WHERE name = ?",
+            (name,),
         ).fetchone()
         if row is None:
             return None
-        return {
-            "taskId": row["task_id"],
-            "pushNotificationConfig": {"url": row["url"], "token": row["token"] or ""},
-        }
+        return json.loads(row["config_json"])
 
-    def list_push_configs(self) -> list[dict]:
+    def list_push_configs(self, task_id: str) -> list[dict]:
         rows = self._conn.execute(
-            "SELECT task_id, url, token FROM push_configs ORDER BY task_id ASC"
+            "SELECT config_json FROM push_configs WHERE task_id = ? ORDER BY config_id ASC",
+            (task_id,),
         ).fetchall()
-        return [
-            {
-                "taskId": row["task_id"],
-                "pushNotificationConfig": {"url": row["url"], "token": row["token"] or ""},
-            }
-            for row in rows
-        ]
+        return [json.loads(row["config_json"]) for row in rows]
 
-    def delete_push_config(self, task_id: str) -> None:
+    def delete_push_config(self, name: str) -> None:
         with self._lock, self._conn:
-            self._conn.execute("DELETE FROM push_configs WHERE task_id = ?", (task_id,))
+            self._conn.execute("DELETE FROM push_configs WHERE name = ?", (name,))
+
+    def list_push_configs_for_task(self, task_id: str) -> list[dict]:
+        return self.list_push_configs(task_id)
 
     def set_remote_task(self, task_id: str, agent_url: str, remote_task_id: str) -> None:
         now = utc_timestamp()

--- a/src/hermes_a2a/tools.py
+++ b/src/hermes_a2a/tools.py
@@ -132,9 +132,9 @@ def tool_a2a_delegate(args: dict[str, Any], **kwargs) -> str:
             # final task snapshot; the store only persists the final task.
             events = list(client.stream_message(message, task_id=task_id, context_id=context_id))
             final_task = None
-            for event in events:
-                if event["event"] == "task":
-                    final_task = event["data"]
+            for stream_response in events:
+                if "task" in stream_response:
+                    final_task = stream_response["task"]
             if final_task is None:
                 raise A2AClientError("Remote stream did not yield a final task snapshot")
             final_task.setdefault("metadata", {}).update(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,14 +1,18 @@
-"""Integration tests for inbound and outbound A2A flows."""
+"""Integration tests for inbound and outbound A2A 1.0 flows."""
 
 from __future__ import annotations
 
 import json
 import os
 import tempfile
+import threading
 import unittest
 import urllib.request
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from unittest import mock
+from uuid import uuid4
 
 ROOT = Path(__file__).resolve().parents[1]
 sys_path = str(ROOT / "src")
@@ -16,6 +20,14 @@ if sys_path not in os.sys.path:
     os.sys.path.insert(0, sys_path)
 
 from hermes_a2a.config import A2APluginConfig
+from hermes_a2a.protocol import (
+    ERROR_METHOD_NOT_FOUND,
+    ERROR_UNSUPPORTED_OPERATION,
+    ERROR_VERSION_NOT_SUPPORTED,
+    PROTOCOL_VERSION,
+    push_config_name,
+    task_name,
+)
 from hermes_a2a.server import create_server
 from hermes_a2a.tools import tool_a2a_delegate, tool_a2a_get_task
 
@@ -37,16 +49,82 @@ class ServerTests(unittest.TestCase):
         self.server.stop()
         self.tmpdir.cleanup()
 
-    def _rpc(self, method: str, params: dict, accept: str = "application/json"):
+    def _message(self, text: str, task_id: str = "", context_id: str = "") -> dict:
+        message = {
+            "messageId": str(uuid4()),
+            "role": "ROLE_USER",
+            "parts": [{"text": text}],
+        }
+        if task_id:
+            message["taskId"] = task_id
+        if context_id:
+            message["contextId"] = context_id
+        return message
+
+    def _rpc(
+        self,
+        method: str,
+        params: dict,
+        accept: str = "application/json",
+        version: str | None = PROTOCOL_VERSION,
+    ):
         payload = json.dumps(
             {"jsonrpc": "2.0", "id": "test", "method": method, "params": params}
         ).encode("utf-8")
+        headers = {"Content-Type": "application/json", "Accept": accept}
+        if version is not None:
+            headers["A2A-Version"] = version
         request = urllib.request.Request(
             f"{self.server.base_url}/rpc",
             data=payload,
-            headers={"Content-Type": "application/json", "Accept": accept},
+            headers=headers,
         )
         return urllib.request.urlopen(request, timeout=5)
+
+    def _read_rpc(self, method: str, params: dict, version: str | None = PROTOCOL_VERSION) -> dict:
+        with self._rpc(method, params, version=version) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def _read_stream(self, method: str, params: dict) -> list[dict]:
+        with self._rpc(method, params, accept="text/event-stream") as response:
+            body = response.read().decode("utf-8")
+        self.assertNotIn("event:", body)
+        return [
+            json.loads(line.split(":", 1)[1].strip())
+            for line in body.splitlines()
+            if line.startswith("data:")
+        ]
+
+    def _assert_no_legacy_task_fields(self, value) -> None:
+        if isinstance(value, dict):
+            for forbidden in ("kind", "messages", "historyLength", "createdAt", "updatedAt", "type"):
+                self.assertNotIn(forbidden, value)
+            for child in value.values():
+                self._assert_no_legacy_task_fields(child)
+        elif isinstance(value, list):
+            for child in value:
+                self._assert_no_legacy_task_fields(child)
+
+    def _start_callback_server(self):
+        callback = {}
+
+        class PushHandler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler API
+                body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                callback["content_type"] = self.headers.get("Content-Type")
+                callback["authorization"] = self.headers.get("Authorization")
+                callback["payload"] = json.loads(body.decode("utf-8"))
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, format, *args):  # noqa: A003 - inherited name
+                del format, args
+
+        callback_server = HTTPServer(("127.0.0.1", 0), PushHandler)
+        callback_thread = threading.Thread(target=callback_server.serve_forever, daemon=True)
+        callback_thread.start()
+        callback_url = f"http://127.0.0.1:{callback_server.server_address[1]}/push"
+        return callback, callback_url, callback_server, callback_thread
 
     def test_agent_card_and_core_rpc_round_trip(self) -> None:
         with urllib.request.urlopen(
@@ -54,64 +132,208 @@ class ServerTests(unittest.TestCase):
         ) as response:
             card = json.loads(response.read().decode("utf-8"))
 
-        with self._rpc(
-            "message/send",
-            {"message": {"role": "user", "parts": [{"type": "text", "text": "hello"}]}},
-        ) as response:
-            task_payload = json.loads(response.read().decode("utf-8"))
+        self.assertEqual(card["protocolVersions"], ["1.0"])
+        self.assertEqual(card["supportedInterfaces"][0]["protocolBinding"], "JSONRPC")
+        self.assertNotIn("protocolVersion", card)
+        self.assertNotIn("preferredTransport", card)
+        self.assertEqual(card["skills"][0]["inputModes"], ["text/plain", "application/json"])
 
-        task_id = task_payload["result"]["id"]
+        task_payload = self._read_rpc("SendMessage", {"message": self._message("hello")})
+        task = task_payload["result"]["task"]
+        task_id = task["id"]
+        fetched = self._read_rpc("GetTask", {"name": task_name(task_id), "historyLength": 1})
 
-        with self._rpc("tasks/get", {"id": task_id}) as response:
-            fetched = json.loads(response.read().decode("utf-8"))
-
-        self.assertEqual(card["skills"][0]["id"], "delegate")
-        self.assertEqual(task_payload["result"]["status"]["state"], "completed")
+        self.assertEqual(task["status"]["state"], "TASK_STATE_COMPLETED")
         self.assertEqual(fetched["result"]["id"], task_id)
+        self.assertEqual(len(fetched["result"]["history"]), 1)
+        self._assert_no_legacy_task_fields(task)
 
-    def test_stream_resubscribe_and_push_config_crud(self) -> None:
-        with self._rpc(
-            "message/stream",
-            {"message": {"role": "user", "parts": [{"type": "text", "text": "hello"}]}},
-            accept="text/event-stream",
-        ) as response:
-            stream_body = response.read().decode("utf-8")
-
-        self.assertIn("event: task_status_update", stream_body)
-        self.assertIn("event: task", stream_body)
-        task_data_line = [
-            line for line in stream_body.splitlines() if line.startswith("data: ") and '"id"' in line
-        ][-1]
-        task = json.loads(task_data_line.split(":", 1)[1].strip())
+    def test_stream_subscribe_list_cancel_and_push_config_crud(self) -> None:
+        stream_events = self._read_stream(
+            "SendStreamingMessage",
+            {"message": self._message("hello")},
+        )
+        stream_results = [event["result"] for event in stream_events]
+        self.assertTrue(any("statusUpdate" in result for result in stream_results))
+        self.assertTrue(any("artifactUpdate" in result for result in stream_results))
+        task = stream_results[-1]["task"]
         task_id = task["id"]
 
-        with self._rpc(
-            "tasks/pushNotificationConfig/set",
-            {"id": task_id, "pushNotificationConfig": {"url": "https://callback.test", "token": "tok"}},
-        ) as response:
-            set_payload = json.loads(response.read().decode("utf-8"))
+        list_payload = self._read_rpc(
+            "ListTasks",
+            {
+                "contextId": task["contextId"],
+                "status": "TASK_STATE_COMPLETED",
+                "pageSize": 10,
+            },
+        )
+        self.assertEqual(list_payload["result"]["totalSize"], 1)
+        self.assertEqual(list_payload["result"]["nextPageToken"], "")
+        self.assertNotIn("artifacts", list_payload["result"]["tasks"][0])
 
-        with self._rpc("tasks/pushNotificationConfig/get", {"id": task_id}) as response:
-            get_payload = json.loads(response.read().decode("utf-8"))
+        cancel_payload = self._read_rpc("CancelTask", {"name": task_name(task_id)})
+        self.assertEqual(cancel_payload["result"]["status"]["state"], "TASK_STATE_CANCELLED")
 
-        with self._rpc("tasks/pushNotificationConfig/list", {}) as response:
-            list_payload = json.loads(response.read().decode("utf-8"))
+        input_payload = self._read_rpc("SendMessage", {"message": self._message("need input")})
+        input_task = input_payload["result"]["task"]
+        replay = self._read_stream("SubscribeToTask", {"name": task_name(input_task["id"])})
+        self.assertIn("task", replay[0]["result"])
+        self.assertEqual(replay[0]["result"]["task"]["status"]["state"], "TASK_STATE_INPUT_REQUIRED")
 
-        with self._rpc(
-            "tasks/resubscribe",
-            {"id": task_id, "afterSeq": 0},
-            accept="text/event-stream",
-        ) as response:
-            replay = response.read().decode("utf-8")
+        callback, callback_url, callback_server, callback_thread = self._start_callback_server()
 
-        with self._rpc("tasks/pushNotificationConfig/delete", {"id": task_id}) as response:
-            delete_payload = json.loads(response.read().decode("utf-8"))
+        config_name = push_config_name(task_id, "cfg-1")
+        set_payload = self._read_rpc(
+            "CreateTaskPushNotificationConfig",
+            {
+                "parent": task_name(task_id),
+                "configId": "cfg-1",
+                "config": {
+                    "pushNotificationConfig": {
+                        "url": callback_url,
+                        "token": "tok",
+                        "authentication": {
+                            "schemes": ["Bearer"],
+                            "credentials": "secret",
+                        },
+                    }
+                },
+            },
+        )
+        get_payload = self._read_rpc("GetTaskPushNotificationConfig", {"name": config_name})
+        list_configs = self._read_rpc("ListTaskPushNotificationConfig", {"parent": task_name(task_id)})
 
-        self.assertEqual(set_payload["result"]["taskId"], task_id)
-        self.assertEqual(get_payload["result"]["pushNotificationConfig"]["url"], "https://callback.test")
-        self.assertEqual(len(list_payload["result"]), 1)
-        self.assertIn("event: task_artifact_update", replay)
+        self.assertEqual(set_payload["result"]["name"], config_name)
+        self.assertEqual(get_payload["result"]["pushNotificationConfig"]["url"], callback_url)
+        self.assertEqual(len(list_configs["result"]["configs"]), 1)
+        self.assertEqual(list_configs["result"]["nextPageToken"], "")
+
+        try:
+            self._read_rpc(
+                "SendMessage",
+                {
+                    "message": self._message(
+                        "follow up",
+                        task_id=task_id,
+                        context_id=task["contextId"],
+                    )
+                },
+            )
+        finally:
+            callback_server.shutdown()
+            callback_server.server_close()
+            callback_thread.join(timeout=2)
+
+        self.assertEqual(callback["content_type"], "application/a2a+json")
+        self.assertEqual(callback["authorization"], "Bearer secret")
+        self.assertIn("statusUpdate", callback["payload"])
+
+        delete_payload = self._read_rpc("DeleteTaskPushNotificationConfig", {"name": config_name})
         self.assertIsNone(delete_payload["result"])
+
+    def test_send_message_configuration_registers_push_config(self) -> None:
+        callback, callback_url, callback_server, callback_thread = self._start_callback_server()
+        try:
+            payload = self._read_rpc(
+                "SendMessage",
+                {
+                    "message": self._message("hello with inline callback"),
+                    "configuration": {
+                        "pushNotificationConfig": {
+                            "id": "inline",
+                            "url": callback_url,
+                            "authentication": {
+                                "schemes": ["Bearer"],
+                                "credentials": "inline-secret",
+                            },
+                        }
+                    },
+                },
+            )
+        finally:
+            callback_server.shutdown()
+            callback_server.server_close()
+            callback_thread.join(timeout=2)
+
+        task = payload["result"]["task"]
+        config_name = push_config_name(task["id"], "inline")
+        stored = self._read_rpc("GetTaskPushNotificationConfig", {"name": config_name})
+
+        self.assertEqual(stored["result"]["pushNotificationConfig"]["url"], callback_url)
+        self.assertEqual(callback["content_type"], "application/a2a+json")
+        self.assertEqual(callback["authorization"], "Bearer inline-secret")
+        self.assertIn("statusUpdate", callback["payload"])
+
+    def test_data_and_file_parts_are_not_silently_dropped(self) -> None:
+        data_payload = self._read_rpc(
+            "SendMessage",
+            {
+                "message": {
+                    "messageId": str(uuid4()),
+                    "role": "ROLE_USER",
+                    "parts": [{"data": {"data": {"question": "structured"}}}],
+                }
+            },
+        )
+        data_artifact = data_payload["result"]["task"]["artifacts"][0]["parts"][0]["text"]
+        self.assertIn('"question": "structured"', data_artifact)
+
+        file_payload = self._read_rpc(
+            "SendMessage",
+            {
+                "message": {
+                    "messageId": str(uuid4()),
+                    "role": "ROLE_USER",
+                    "parts": [
+                        {
+                            "file": {
+                                "fileWithUri": "https://example.test/doc.txt",
+                                "name": "doc.txt",
+                                "mediaType": "text/plain",
+                            }
+                        }
+                    ],
+                }
+            },
+        )
+        file_artifact = file_payload["result"]["task"]["artifacts"][0]["parts"][0]["file"][
+            "fileWithUri"
+        ]
+        self.assertIn("https://example.test/doc.txt", file_artifact)
+        self.assertIn("mediaType=text/plain", file_artifact)
+
+    def test_list_tasks_status_timestamp_after_parses_offsets(self) -> None:
+        payload = self._read_rpc("SendMessage", {"message": self._message("offset filter")})
+        task = payload["result"]["task"]
+        timestamp = task["status"]["timestamp"]
+        timestamp_dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        equivalent_offset = timestamp_dt.astimezone(timezone(timedelta(hours=1))).isoformat(
+            timespec="milliseconds"
+        )
+
+        listed = self._read_rpc(
+            "ListTasks",
+            {
+                "statusTimestampAfter": equivalent_offset,
+                "pageSize": 10,
+            },
+        )
+
+        self.assertEqual(listed["result"]["totalSize"], 1)
+        self.assertEqual(listed["result"]["tasks"][0]["id"], task["id"])
+
+    def test_extended_card_version_and_legacy_method_errors(self) -> None:
+        missing_version = self._read_rpc(
+            "SendMessage",
+            {"message": self._message("hello")},
+            version=None,
+        )
+        legacy = self._read_rpc("message/send", {"message": self._message("hello")})
+        extended = self._read_rpc("GetExtendedAgentCard", {})
+
+        self.assertEqual(missing_version["error"]["code"], ERROR_VERSION_NOT_SUPPORTED)
+        self.assertEqual(legacy["error"]["code"], ERROR_METHOD_NOT_FOUND)
+        self.assertEqual(extended["error"]["code"], ERROR_UNSUPPORTED_OPERATION)
 
     def test_outbound_delegate_round_trips_against_local_server(self) -> None:
         env = {
@@ -126,5 +348,5 @@ class ServerTests(unittest.TestCase):
             )
             refreshed = json.loads(tool_a2a_get_task({"task_id": delegated["task"]["id"]}))
 
-        self.assertEqual(delegated["task"]["status"]["state"], "completed")
+        self.assertEqual(delegated["task"]["status"]["state"], "TASK_STATE_COMPLETED")
         self.assertEqual(refreshed["id"], delegated["task"]["id"])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,6 +13,7 @@ if sys_path not in os.sys.path:
     os.sys.path.insert(0, sys_path)
 
 from hermes_a2a.mapping import build_initial_task
+from hermes_a2a.protocol import push_config_name
 from hermes_a2a.store import SQLiteTaskStore
 
 
@@ -20,20 +21,50 @@ class StoreTests(unittest.TestCase):
     def test_store_persists_task_events_and_push_configs(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             store = SQLiteTaskStore(str(Path(tmpdir) / "state.db"))
-            task = build_initial_task("task-1", "ctx-1", "hello", direction="inbound")
+            task = build_initial_task(
+                "task-1",
+                "ctx-1",
+                {
+                    "messageId": "msg-1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hello"}],
+                },
+                direction="inbound",
+            )
             store.upsert_task(task, direction="inbound")
-            seq = store.append_event("task-1", "task_status_update", {"state": "working"})
-            store.set_push_config("task-1", "https://callback.test", "token")
+            seq = store.append_event(
+                "task-1",
+                {
+                    "statusUpdate": {
+                        "taskId": "task-1",
+                        "contextId": "ctx-1",
+                        "status": {"state": "TASK_STATE_WORKING"},
+                        "final": False,
+                    }
+                },
+            )
+            config_name = push_config_name("task-1", "cfg-1")
+            store.set_push_config(
+                "task-1",
+                "cfg-1",
+                {
+                    "name": config_name,
+                    "pushNotificationConfig": {
+                        "url": "https://callback.test",
+                        "token": "token",
+                    },
+                },
+            )
             store.set_remote_task("task-1", "https://agent.test", "task-1")
 
             stored = store.get_task("task-1")
             events = store.list_events("task-1")
-            push = store.get_push_config("task-1")
+            push = store.get_push_config(config_name)
             remote = store.get_remote_task("task-1")
             store.close()
 
         self.assertEqual(stored["id"], "task-1")
         self.assertEqual(seq, 1)
-        self.assertEqual(events[0]["event"], "task_status_update")
+        self.assertEqual(events[0]["statusUpdate"]["status"]["state"], "TASK_STATE_WORKING")
         self.assertEqual(push["pushNotificationConfig"]["url"], "https://callback.test")
         self.assertEqual(remote["agentUrl"], "https://agent.test")


### PR DESCRIPTION
## Summary

Implements the official A2A 1.0 JSON-RPC surface for Hermes A2A and removes the legacy public protocol behavior from the supported path.

## Key Changes

- Added canonical A2A protocol helpers for JSON-RPC envelopes, error codes, stream responses, resource names, and version handling.
- Updated task, message, part, artifact, status, Agent Card, and push notification shapes to match A2A 1.0.
- Reworked inbound RPC dispatch to accept only official method names and enforce `A2A-Version: 1.0`.
- Updated streaming and subscription responses to emit JSON-RPC StreamResponse payloads without custom SSE event names.
- Updated the outbound client to send official request shapes and parse official response wrappers only.
- Persisted official task snapshots, stream-compatible events, and resource-named push notification configs.
- Added coverage for Agent Card, SendMessage, streaming, task operations, push config CRUD, version rejection, legacy method rejection, and regression cases from review.
- Updated docs to describe only the official A2A 1.0 surface.

Closes #3

## Validation

- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`