### PR TITLE
fix: publish A2A 1.0 agent card

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ uv run hermes-a2a card
 
 - Inbound server:
   - `GET /.well-known/agent-card.json`
+    publishes an A2A 1.0 AgentCard with the JSON-RPC endpoint in
+    `supportedInterfaces`; when `A2A_BEARER_TOKEN` is configured, the card
+    advertises the required bearer auth scheme while remaining publicly
+    discoverable.
   - `POST /rpc` for the official A2A 1.0 JSON-RPC methods:
     `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`,
     `CancelTask`, `SubscribeToTask`, `CreateTaskPushNotificationConfig`,

--- a/src/hermes_a2a/mapping.py
+++ b/src/hermes_a2a/mapping.py
@@ -212,11 +212,11 @@ def build_agent_card(config: A2APluginConfig) -> dict:
     card = {
         "name": "Hermes A2A Plugin",
         "description": "Hermes exposed as a bidirectional A2A bridge.",
-        "protocolVersions": [PROTOCOL_VERSION],
         "supportedInterfaces": [
             {
                 "url": config.rpc_url,
                 "protocolBinding": "JSONRPC",
+                "protocolVersion": PROTOCOL_VERSION,
             }
         ],
         "provider": {
@@ -241,7 +241,7 @@ def build_agent_card(config: A2APluginConfig) -> dict:
                 }
             }
         }
-        card["security"] = [{"schemes": {"bearerAuth": {"list": []}}}]
+        card["security"] = [{"bearerAuth": []}]
     return card
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import threading
 import unittest
+import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -132,8 +133,18 @@ class ServerTests(unittest.TestCase):
         ) as response:
             card = json.loads(response.read().decode("utf-8"))
 
-        self.assertEqual(card["protocolVersions"], ["1.0"])
-        self.assertEqual(card["supportedInterfaces"][0]["protocolBinding"], "JSONRPC")
+        self.assertEqual(
+            card["supportedInterfaces"],
+            [
+                {
+                    "url": f"{self.server.base_url}/rpc",
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0",
+                }
+            ],
+        )
+        self.assertNotIn("url", card)
+        self.assertNotIn("protocolVersions", card)
         self.assertNotIn("protocolVersion", card)
         self.assertNotIn("preferredTransport", card)
         self.assertEqual(card["skills"][0]["inputModes"], ["text/plain", "application/json"])
@@ -147,6 +158,57 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(fetched["result"]["id"], task_id)
         self.assertEqual(len(fetched["result"]["history"]), 1)
         self._assert_no_legacy_task_fields(task)
+
+    def test_bearer_agent_card_remains_public_and_declares_security(self) -> None:
+        config = A2APluginConfig(
+            host="127.0.0.1",
+            port=0,
+            store_path=str(Path(self.tmpdir.name) / "auth-server.db"),
+            bearer_token="secret",
+            exported_skills=["delegate"],
+            execution_adapter="demo",
+        )
+        auth_server = create_server(config=config)
+        auth_server.start()
+        try:
+            with urllib.request.urlopen(
+                f"{auth_server.base_url}/.well-known/agent-card.json", timeout=5
+            ) as response:
+                card = json.loads(response.read().decode("utf-8"))
+
+            self.assertEqual(
+                card["securitySchemes"],
+                {
+                    "bearerAuth": {
+                        "httpAuthSecurityScheme": {
+                            "scheme": "Bearer",
+                        }
+                    }
+                },
+            )
+            self.assertEqual(card["security"], [{"bearerAuth": []}])
+
+            payload = json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "test",
+                    "method": "SendMessage",
+                    "params": {"message": self._message("hello")},
+                }
+            ).encode("utf-8")
+            request = urllib.request.Request(
+                f"{auth_server.base_url}/rpc",
+                data=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "A2A-Version": PROTOCOL_VERSION,
+                },
+            )
+            with self.assertRaises(urllib.error.HTTPError) as raised:
+                urllib.request.urlopen(request, timeout=5)
+            self.assertEqual(raised.exception.code, 401)
+        finally:
+            auth_server.stop()
 
     def test_stream_subscribe_list_cancel_and_push_config_crud(self) -> None:
         stream_events = self._read_stream(


### PR DESCRIPTION
## Summary

Publishes the AgentCard using the A2A 1.0 discovery model by moving JSON-RPC protocol versioning into `supportedInterfaces` and removing legacy top-level version/transport fields.

## Key Changes

- Adds `protocolVersion: "1.0"` to the JSON-RPC `supportedInterfaces` entry.
- Removes the top-level `protocolVersions` compatibility field from the public card.
- Emits bearer security requirements as `security: [{"bearerAuth": []}]` when `A2A_BEARER_TOKEN` is configured.
- Adds regression coverage for strict AgentCard interface shape and public bearer-auth discovery.
- Documents the public discovery behavior in the README.

## Validation

- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- Result: `Ran 25 tests in 5.657s` / `OK`

Closes #4