### PR TITLE
fix: normalize A2A protocol shapes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ The current inbound server exposes:
 - `POST /rpc` for official A2A 1.0 JSON-RPC methods: `SendMessage`,
   `SendStreamingMessage`, `GetTask`, `ListTasks`, `CancelTask`,
   `SubscribeToTask`, `CreateTaskPushNotificationConfig`,
-  `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfig`,
+  `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfigs`,
   `DeleteTaskPushNotificationConfig`, and `GetExtendedAgentCard`
 
 Legacy slash-style JSON-RPC methods and custom SSE replay endpoints are not

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ uv run hermes-a2a card
   - `POST /rpc` for the official A2A 1.0 JSON-RPC methods:
     `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`,
     `CancelTask`, `SubscribeToTask`, `CreateTaskPushNotificationConfig`,
-    `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfig`,
+    `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfigs`,
     `DeleteTaskPushNotificationConfig`, and `GetExtendedAgentCard`
 - Outbound Hermes tools:
   - `a2a_status`
@@ -137,6 +137,10 @@ The plugin is configured through environment variables:
 
 - JSON-RPC requests must include `A2A-Version: 1.0`. Legacy slash-style methods
   such as `message/send` and old task/message/part response fields are not
+  supported.
+- Task RPCs use direct task IDs in params such as `{"id": "task-id"}`. Push
+  notification config RPCs use `taskId`, config `id`, and
+  `pushNotificationConfig`; resource-name params such as `tasks/{id}` are not
   supported.
 - By default the inbound server routes A2A `SendMessage` and
   `SendStreamingMessage` calls through `hermes chat -q ... --quiet`. Set

--- a/src/hermes_a2a/adapter.py
+++ b/src/hermes_a2a/adapter.py
@@ -213,7 +213,7 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
         return [
             HermesEvent(
                 kind="status",
-                state="cancelled",
+                state="canceled",
                 message="Hermes runtime subprocess cancellation requested",
                 metadata={"task_id": task_id, "context_id": context_id},
             )
@@ -350,7 +350,7 @@ class DemoHermesExecutionAdapter(HermesExecutionAdapter):
         return [
             HermesEvent(
                 kind="status",
-                state="cancelled",
+                state="canceled",
                 message="Hermes execution cancelled",
                 metadata={"task_id": task_id, "context_id": context_id},
             )

--- a/src/hermes_a2a/client.py
+++ b/src/hermes_a2a/client.py
@@ -16,7 +16,6 @@ from .protocol import (
     METHOD_SEND_MESSAGE,
     METHOD_SEND_STREAMING_MESSAGE,
     PROTOCOL_VERSION,
-    task_name,
 )
 
 
@@ -153,7 +152,7 @@ class A2AClient:
             "jsonrpc": "2.0",
             "id": "task-get",
             "method": METHOD_GET_TASK,
-            "params": {"name": task_name(task_id)},
+            "params": {"id": task_id},
         }
         with self._request("/rpc", request) as response:
             payload = json.loads(response.read().decode("utf-8"))
@@ -166,7 +165,7 @@ class A2AClient:
             "jsonrpc": "2.0",
             "id": "task-cancel",
             "method": METHOD_CANCEL_TASK,
-            "params": {"name": task_name(task_id)},
+            "params": {"id": task_id},
         }
         with self._request("/rpc", request) as response:
             payload = json.loads(response.read().decode("utf-8"))

--- a/src/hermes_a2a/mapping.py
+++ b/src/hermes_a2a/mapping.py
@@ -32,29 +32,39 @@ def extract_text_from_message(message: dict | None) -> str:
     for part in parts:
         if not isinstance(part, dict):
             raise ValueError("Message.parts entries must be objects")
-        if isinstance(part.get("text"), str):
+        content_fields = [field for field in ("text", "raw", "url", "data") if field in part]
+        if len(content_fields) != 1:
+            raise ValueError("Message.parts entries must contain exactly one of text, raw, url, or data")
+        field = content_fields[0]
+        if field == "text":
+            if not isinstance(part["text"], str):
+                raise ValueError("Text parts must contain string text")
             texts.append(part["text"])
             continue
-        if isinstance(part.get("data"), dict):
-            data_part = part["data"]
-            data = data_part.get("data") if isinstance(data_part.get("data"), dict) else data_part
-            texts.append(json.dumps(data, sort_keys=True))
+        if field == "data":
+            texts.append("data: " + json.dumps(part["data"], sort_keys=True))
             continue
-        if isinstance(part.get("file"), dict):
-            file_part = part["file"]
-            file_ref = file_part.get("fileWithUri") or file_part.get("fileWithBytes")
-            if not file_ref:
-                raise ValueError("File parts must include fileWithUri or fileWithBytes")
-            details = [str(file_ref)]
-            if file_part.get("name"):
-                details.append(f"name={file_part['name']}")
-            if file_part.get("mediaType"):
-                details.append(f"mediaType={file_part['mediaType']}")
+        if field == "url":
+            if not isinstance(part["url"], str):
+                raise ValueError("URL parts must contain string url")
+            details = [part["url"]]
+            if part.get("filename"):
+                details.append(f"filename={part['filename']}")
+            if part.get("mediaType"):
+                details.append(f"mediaType={part['mediaType']}")
             texts.append("file: " + " ".join(details))
             continue
-        raise ValueError("Message.parts entries must contain text, data, or file")
+        if not isinstance(part["raw"], str):
+            raise ValueError("Raw parts must contain base64 string raw content")
+        details = [part["raw"]]
+        if part.get("filename"):
+            details.append(f"filename={part['filename']}")
+        if part.get("mediaType"):
+            details.append(f"mediaType={part['mediaType']}")
+        texts.append("raw: " + " ".join(details))
+        continue
     if not texts:
-        raise ValueError("Message.parts must contain text, data, or file content")
+        raise ValueError("Message.parts must contain text, raw, url, or data content")
     return "\n".join(texts)
 
 
@@ -62,12 +72,12 @@ def build_text_part(text: str) -> dict:
     return {"text": text}
 
 
-def build_data_part(data: dict) -> dict:
-    return {"data": {"data": data}}
+def build_data_part(data) -> dict:
+    return {"data": data, "mediaType": "application/json"}
 
 
 def build_file_part(uri: str) -> dict:
-    return {"file": {"fileWithUri": uri}}
+    return {"url": uri}
 
 
 def build_message(
@@ -171,12 +181,6 @@ def apply_hermes_event(task: dict, event: HermesEvent) -> dict:
                 "taskId": task["id"],
                 "contextId": task["contextId"],
                 "status": task["status"],
-                "final": state in {
-                    "TASK_STATE_COMPLETED",
-                    "TASK_STATE_FAILED",
-                    "TASK_STATE_CANCELLED",
-                    "TASK_STATE_REJECTED",
-                },
             },
         }
 

--- a/src/hermes_a2a/protocol.py
+++ b/src/hermes_a2a/protocol.py
@@ -20,7 +20,7 @@ METHOD_CANCEL_TASK = "CancelTask"
 METHOD_SUBSCRIBE_TO_TASK = "SubscribeToTask"
 METHOD_CREATE_PUSH_CONFIG = "CreateTaskPushNotificationConfig"
 METHOD_GET_PUSH_CONFIG = "GetTaskPushNotificationConfig"
-METHOD_LIST_PUSH_CONFIGS = "ListTaskPushNotificationConfig"
+METHOD_LIST_PUSH_CONFIGS = "ListTaskPushNotificationConfigs"
 METHOD_DELETE_PUSH_CONFIG = "DeleteTaskPushNotificationConfig"
 METHOD_GET_EXTENDED_AGENT_CARD = "GetExtendedAgentCard"
 
@@ -28,7 +28,7 @@ TASK_STATE_SUBMITTED = "TASK_STATE_SUBMITTED"
 TASK_STATE_WORKING = "TASK_STATE_WORKING"
 TASK_STATE_COMPLETED = "TASK_STATE_COMPLETED"
 TASK_STATE_FAILED = "TASK_STATE_FAILED"
-TASK_STATE_CANCELLED = "TASK_STATE_CANCELLED"
+TASK_STATE_CANCELED = "TASK_STATE_CANCELED"
 TASK_STATE_INPUT_REQUIRED = "TASK_STATE_INPUT_REQUIRED"
 TASK_STATE_REJECTED = "TASK_STATE_REJECTED"
 TASK_STATE_AUTH_REQUIRED = "TASK_STATE_AUTH_REQUIRED"
@@ -36,7 +36,7 @@ TASK_STATE_AUTH_REQUIRED = "TASK_STATE_AUTH_REQUIRED"
 TERMINAL_TASK_STATES = {
     TASK_STATE_COMPLETED,
     TASK_STATE_FAILED,
-    TASK_STATE_CANCELLED,
+    TASK_STATE_CANCELED,
     TASK_STATE_REJECTED,
 }
 
@@ -53,8 +53,7 @@ STATE_MAP = {
     "working": TASK_STATE_WORKING,
     "completed": TASK_STATE_COMPLETED,
     "failed": TASK_STATE_FAILED,
-    "cancelled": TASK_STATE_CANCELLED,
-    "canceled": TASK_STATE_CANCELLED,
+    "canceled": TASK_STATE_CANCELED,
     "input-required": TASK_STATE_INPUT_REQUIRED,
     "input_required": TASK_STATE_INPUT_REQUIRED,
     "requires-input": TASK_STATE_INPUT_REQUIRED,
@@ -85,36 +84,8 @@ def jsonrpc_error(request_id, code: int, message: str) -> dict:
     return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
 
 
-def task_name(task_id: str) -> str:
-    return f"tasks/{task_id}"
-
-
-def parse_task_name(name: str) -> str:
-    value = str(name or "").strip()
-    prefix = "tasks/"
-    if not value.startswith(prefix) or "/" in value[len(prefix):] or not value[len(prefix):]:
-        raise ValueError("Expected task resource name in format tasks/{task_id}")
-    return value[len(prefix):]
-
-
 def push_config_name(task_id: str, config_id: str) -> str:
     return f"tasks/{task_id}/pushNotificationConfigs/{config_id}"
-
-
-def parse_push_config_name(name: str) -> tuple[str, str]:
-    value = str(name or "").strip()
-    parts = value.split("/")
-    if len(parts) != 4 or parts[0] != "tasks" or parts[2] != "pushNotificationConfigs":
-        raise ValueError(
-            "Expected push config resource name in format "
-            "tasks/{task_id}/pushNotificationConfigs/{config_id}"
-        )
-    if not parts[1] or not parts[3]:
-        raise ValueError(
-            "Expected push config resource name in format "
-            "tasks/{task_id}/pushNotificationConfigs/{config_id}"
-        )
-    return parts[1], parts[3]
 
 
 def encode_page_token(offset: int) -> str:

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -55,9 +55,7 @@ from .protocol import (
     encode_task_page_token,
     jsonrpc_error,
     jsonrpc_success,
-    parse_push_config_name,
     parse_rfc3339_timestamp,
-    parse_task_name,
     push_config_name,
 )
 from .store import SQLiteTaskStore
@@ -76,6 +74,13 @@ def _build_execution_adapter(config: A2APluginConfig) -> HermesExecutionAdapter:
         "Unsupported A2A_EXECUTION_ADAPTER "
         f"{config.execution_adapter!r}; expected 'hermes' or 'demo'"
     )
+
+
+def _required_string(params: dict, field: str) -> str:
+    value = str(params.get(field) or "").strip()
+    if not value:
+        raise ValueError(f"{field} is required")
+    return value
 
 
 class A2AService:
@@ -134,12 +139,10 @@ class A2AService:
             payload = json.dumps(stream_response, sort_keys=True).encode("utf-8")
             headers = {"Content-Type": A2A_CONTENT_TYPE}
             auth = push_config.get("authentication") or {}
-            schemes = [str(scheme).lower() for scheme in auth.get("schemes", [])]
+            scheme = str(auth.get("scheme") or "").strip()
             credentials = str(auth.get("credentials", "")).strip()
-            if credentials and "bearer" in schemes:
-                headers["Authorization"] = f"Bearer {credentials}"
-            elif credentials and schemes:
-                headers["Authorization"] = f"{schemes[0]} {credentials}"
+            if credentials and scheme:
+                headers["Authorization"] = f"{scheme} {credentials}"
             request = urllib.request.Request(
                 push_config["url"],
                 data=payload,
@@ -210,11 +213,19 @@ class A2AService:
     def _configure_push_from_send_message(self, task_id: str, configuration: dict) -> None:
         if not isinstance(configuration, dict):
             raise ValueError("SendMessageRequest.configuration must be an object")
-        push_config = configuration.get("pushNotificationConfig")
+        push_config_wrapper = configuration.get("taskPushNotificationConfig")
+        if push_config_wrapper is None:
+            return
+        if not isinstance(push_config_wrapper, dict):
+            raise ValueError("configuration.taskPushNotificationConfig must be an object")
+        configured_task_id = str(push_config_wrapper.get("taskId") or "").strip()
+        if configured_task_id and configured_task_id != task_id:
+            raise ValueError("taskPushNotificationConfig.taskId must be empty or match the task id")
+        push_config = push_config_wrapper.get("pushNotificationConfig")
         if push_config is None:
             return
         if not isinstance(push_config, dict):
-            raise ValueError("configuration.pushNotificationConfig must be an object")
+            raise ValueError("taskPushNotificationConfig.pushNotificationConfig must be an object")
         if not str(push_config.get("url", "")).strip():
             raise ValueError("pushNotificationConfig.url is required")
         config_id = str(push_config.get("id") or uuid4()).strip()
@@ -223,10 +234,7 @@ class A2AService:
         self.store.set_push_config(
             task_id,
             config_id,
-            {
-                "name": push_config_name(task_id, config_id),
-                "pushNotificationConfig": stored_push_config,
-            },
+            {"pushNotificationConfig": stored_push_config},
         )
 
     def get_task(self, task_id: str) -> dict:
@@ -310,36 +318,33 @@ class A2AService:
         }
 
     def create_push_config(self, params: dict) -> dict:
-        task_id = parse_task_name(str(params.get("parent") or ""))
+        task_id = _required_string(params, "taskId")
         self.get_task(task_id)
-        config_id = str(params.get("configId") or "").strip()
-        if not config_id:
-            raise ValueError("configId is required")
-        config = params.get("config") or {}
-        push_config = config.get("pushNotificationConfig") if isinstance(config, dict) else None
+        push_config = params.get("pushNotificationConfig")
         if not isinstance(push_config, dict):
-            raise ValueError("config.pushNotificationConfig is required")
+            raise ValueError("pushNotificationConfig is required")
         if not str(push_config.get("url", "")).strip():
             raise ValueError("pushNotificationConfig.url is required")
+        config_id = str(push_config.get("id") or uuid4()).strip()
+        stored_push_config = dict(push_config)
+        stored_push_config["id"] = config_id
         return self.store.set_push_config(
             task_id,
             config_id,
-            {
-                "name": push_config_name(task_id, config_id),
-                "pushNotificationConfig": push_config,
-            },
+            {"pushNotificationConfig": stored_push_config},
         )
 
     def get_push_config(self, params: dict) -> dict:
-        name = str(params.get("name") or "")
-        parse_push_config_name(name)
+        task_id = _required_string(params, "taskId")
+        config_id = _required_string(params, "id")
+        name = push_config_name(task_id, config_id)
         result = self.store.get_push_config(name)
         if result is None:
             raise KeyError(name)
         return result
 
     def list_push_configs(self, params: dict) -> dict:
-        task_id = parse_task_name(str(params.get("parent") or ""))
+        task_id = _required_string(params, "taskId")
         self.get_task(task_id)
         page_size = int(params.get("pageSize") or 50)
         if page_size < 1 or page_size > 100:
@@ -354,8 +359,9 @@ class A2AService:
         }
 
     def delete_push_config(self, params: dict) -> None:
-        name = str(params.get("name") or "")
-        parse_push_config_name(name)
+        task_id = _required_string(params, "taskId")
+        config_id = _required_string(params, "id")
+        name = push_config_name(task_id, config_id)
         if self.store.get_push_config(name) is None:
             raise KeyError(name)
         self.store.delete_push_config(name)
@@ -471,7 +477,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
                 return
 
             if method == METHOD_GET_TASK:
-                task_id = parse_task_name(str(params.get("name") or ""))
+                task_id = _required_string(params, "id")
                 history_length = params.get("historyLength")
                 task = trim_task_for_response(
                     self._service.get_task(task_id),
@@ -485,12 +491,12 @@ class _RequestHandler(BaseHTTPRequestHandler):
                 return
 
             if method == METHOD_CANCEL_TASK:
-                task_id = parse_task_name(str(params.get("name") or ""))
+                task_id = _required_string(params, "id")
                 self._send_json(jsonrpc_success(request_id, self._service.cancel_task(task_id)))
                 return
 
             if method == METHOD_SUBSCRIBE_TO_TASK:
-                task_id = parse_task_name(str(params.get("name") or ""))
+                task_id = _required_string(params, "id")
                 self._send_stream(request_id, self._service.subscribe_task(task_id))
                 return
 

--- a/src/hermes_a2a/store.py
+++ b/src/hermes_a2a/store.py
@@ -153,7 +153,7 @@ class SQLiteTaskStore:
         push_config.setdefault("id", config_id)
         push_config.setdefault("url", "")
         push_config.setdefault("token", "")
-        stored = {"name": name, "pushNotificationConfig": push_config}
+        stored = {"taskId": task_id, "pushNotificationConfig": push_config}
         with self._lock, self._conn:
             self._conn.execute(
                 """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,12 +21,11 @@ if sys_path not in os.sys.path:
 
 from hermes_a2a.config import A2APluginConfig
 from hermes_a2a.protocol import (
+    ERROR_INVALID_PARAMS,
     ERROR_METHOD_NOT_FOUND,
     ERROR_UNSUPPORTED_OPERATION,
     ERROR_VERSION_NOT_SUPPORTED,
     PROTOCOL_VERSION,
-    push_config_name,
-    task_name,
 )
 from hermes_a2a.server import create_server
 from hermes_a2a.tools import tool_a2a_delegate, tool_a2a_get_task
@@ -105,6 +104,50 @@ class ServerTests(unittest.TestCase):
             for child in value:
                 self._assert_no_legacy_task_fields(child)
 
+    def _assert_one_of(self, value: dict, fields: tuple[str, ...]) -> str:
+        present = [field for field in fields if field in value]
+        self.assertEqual(len(present), 1)
+        return present[0]
+
+    def _assert_stream_response(self, value: dict) -> str:
+        field = self._assert_one_of(value, ("task", "message", "statusUpdate", "artifactUpdate"))
+        if field == "statusUpdate":
+            self.assertNotIn("final", value["statusUpdate"])
+        return field
+
+    def _assert_part(self, part: dict) -> str:
+        field = self._assert_one_of(part, ("text", "raw", "url", "data"))
+        self.assertNotIn("file", part)
+        self.assertNotIn("kind", part)
+        self.assertNotIn("type", part)
+        return field
+
+    def _assert_message(self, message: dict) -> None:
+        self.assertIn(message["role"], {"ROLE_USER", "ROLE_AGENT"})
+        self.assertTrue(message["messageId"])
+        for part in message["parts"]:
+            self._assert_part(part)
+
+    def _assert_task(self, task: dict) -> None:
+        self._assert_no_legacy_task_fields(task)
+        self.assertIn("history", task)
+        self.assertNotIn("messages", task)
+        self.assertIn(task["status"]["state"], {
+            "TASK_STATE_SUBMITTED",
+            "TASK_STATE_WORKING",
+            "TASK_STATE_COMPLETED",
+            "TASK_STATE_FAILED",
+            "TASK_STATE_CANCELED",
+            "TASK_STATE_INPUT_REQUIRED",
+            "TASK_STATE_REJECTED",
+            "TASK_STATE_AUTH_REQUIRED",
+        })
+        for message in task.get("history", []):
+            self._assert_message(message)
+        for artifact in task.get("artifacts", []):
+            for part in artifact["parts"]:
+                self._assert_part(part)
+
     def _start_callback_server(self):
         callback = {}
 
@@ -139,14 +182,15 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(card["skills"][0]["inputModes"], ["text/plain", "application/json"])
 
         task_payload = self._read_rpc("SendMessage", {"message": self._message("hello")})
+        self.assertEqual(self._assert_one_of(task_payload["result"], ("task", "message")), "task")
         task = task_payload["result"]["task"]
         task_id = task["id"]
-        fetched = self._read_rpc("GetTask", {"name": task_name(task_id), "historyLength": 1})
+        fetched = self._read_rpc("GetTask", {"id": task_id, "historyLength": 1})
 
         self.assertEqual(task["status"]["state"], "TASK_STATE_COMPLETED")
         self.assertEqual(fetched["result"]["id"], task_id)
         self.assertEqual(len(fetched["result"]["history"]), 1)
-        self._assert_no_legacy_task_fields(task)
+        self._assert_task(task)
 
     def test_stream_subscribe_list_cancel_and_push_config_crud(self) -> None:
         stream_events = self._read_stream(
@@ -154,10 +198,13 @@ class ServerTests(unittest.TestCase):
             {"message": self._message("hello")},
         )
         stream_results = [event["result"] for event in stream_events]
+        for result in stream_results:
+            self._assert_stream_response(result)
         self.assertTrue(any("statusUpdate" in result for result in stream_results))
         self.assertTrue(any("artifactUpdate" in result for result in stream_results))
         task = stream_results[-1]["task"]
         task_id = task["id"]
+        self._assert_task(task)
 
         list_payload = self._read_rpc(
             "ListTasks",
@@ -171,39 +218,37 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(list_payload["result"]["nextPageToken"], "")
         self.assertNotIn("artifacts", list_payload["result"]["tasks"][0])
 
-        cancel_payload = self._read_rpc("CancelTask", {"name": task_name(task_id)})
-        self.assertEqual(cancel_payload["result"]["status"]["state"], "TASK_STATE_CANCELLED")
+        cancel_payload = self._read_rpc("CancelTask", {"id": task_id})
+        self.assertEqual(cancel_payload["result"]["status"]["state"], "TASK_STATE_CANCELED")
 
         input_payload = self._read_rpc("SendMessage", {"message": self._message("need input")})
         input_task = input_payload["result"]["task"]
-        replay = self._read_stream("SubscribeToTask", {"name": task_name(input_task["id"])})
+        replay = self._read_stream("SubscribeToTask", {"id": input_task["id"]})
         self.assertIn("task", replay[0]["result"])
         self.assertEqual(replay[0]["result"]["task"]["status"]["state"], "TASK_STATE_INPUT_REQUIRED")
 
         callback, callback_url, callback_server, callback_thread = self._start_callback_server()
 
-        config_name = push_config_name(task_id, "cfg-1")
         set_payload = self._read_rpc(
             "CreateTaskPushNotificationConfig",
             {
-                "parent": task_name(task_id),
-                "configId": "cfg-1",
-                "config": {
-                    "pushNotificationConfig": {
-                        "url": callback_url,
-                        "token": "tok",
-                        "authentication": {
-                            "schemes": ["Bearer"],
-                            "credentials": "secret",
-                        },
-                    }
+                "taskId": task_id,
+                "pushNotificationConfig": {
+                    "id": "cfg-1",
+                    "url": callback_url,
+                    "token": "tok",
+                    "authentication": {
+                        "scheme": "Bearer",
+                        "credentials": "secret",
+                    },
                 },
             },
         )
-        get_payload = self._read_rpc("GetTaskPushNotificationConfig", {"name": config_name})
-        list_configs = self._read_rpc("ListTaskPushNotificationConfig", {"parent": task_name(task_id)})
+        get_payload = self._read_rpc("GetTaskPushNotificationConfig", {"taskId": task_id, "id": "cfg-1"})
+        list_configs = self._read_rpc("ListTaskPushNotificationConfigs", {"taskId": task_id})
 
-        self.assertEqual(set_payload["result"]["name"], config_name)
+        self.assertEqual(set_payload["result"]["taskId"], task_id)
+        self.assertEqual(set_payload["result"]["pushNotificationConfig"]["id"], "cfg-1")
         self.assertEqual(get_payload["result"]["pushNotificationConfig"]["url"], callback_url)
         self.assertEqual(len(list_configs["result"]["configs"]), 1)
         self.assertEqual(list_configs["result"]["nextPageToken"], "")
@@ -227,8 +272,12 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(callback["content_type"], "application/a2a+json")
         self.assertEqual(callback["authorization"], "Bearer secret")
         self.assertIn("statusUpdate", callback["payload"])
+        self._assert_stream_response(callback["payload"])
 
-        delete_payload = self._read_rpc("DeleteTaskPushNotificationConfig", {"name": config_name})
+        delete_payload = self._read_rpc(
+            "DeleteTaskPushNotificationConfig",
+            {"taskId": task_id, "id": "cfg-1"},
+        )
         self.assertIsNone(delete_payload["result"])
 
     def test_send_message_configuration_registers_push_config(self) -> None:
@@ -239,12 +288,15 @@ class ServerTests(unittest.TestCase):
                 {
                     "message": self._message("hello with inline callback"),
                     "configuration": {
-                        "pushNotificationConfig": {
-                            "id": "inline",
-                            "url": callback_url,
-                            "authentication": {
-                                "schemes": ["Bearer"],
-                                "credentials": "inline-secret",
+                        "taskPushNotificationConfig": {
+                            "taskId": "",
+                            "pushNotificationConfig": {
+                                "id": "inline",
+                                "url": callback_url,
+                                "authentication": {
+                                    "scheme": "Bearer",
+                                    "credentials": "inline-secret",
+                                },
                             },
                         }
                     },
@@ -256,29 +308,31 @@ class ServerTests(unittest.TestCase):
             callback_thread.join(timeout=2)
 
         task = payload["result"]["task"]
-        config_name = push_config_name(task["id"], "inline")
-        stored = self._read_rpc("GetTaskPushNotificationConfig", {"name": config_name})
+        stored = self._read_rpc("GetTaskPushNotificationConfig", {"taskId": task["id"], "id": "inline"})
 
         self.assertEqual(stored["result"]["pushNotificationConfig"]["url"], callback_url)
         self.assertEqual(callback["content_type"], "application/a2a+json")
         self.assertEqual(callback["authorization"], "Bearer inline-secret")
         self.assertIn("statusUpdate", callback["payload"])
+        self._assert_stream_response(callback["payload"])
 
-    def test_data_and_file_parts_are_not_silently_dropped(self) -> None:
+    def test_official_part_shapes_are_not_silently_dropped(self) -> None:
         data_payload = self._read_rpc(
             "SendMessage",
             {
                 "message": {
                     "messageId": str(uuid4()),
                     "role": "ROLE_USER",
-                    "parts": [{"data": {"data": {"question": "structured"}}}],
+                    "parts": [{"data": {"question": "structured"}}],
                 }
             },
         )
-        data_artifact = data_payload["result"]["task"]["artifacts"][0]["parts"][0]["text"]
-        self.assertIn('"question": "structured"', data_artifact)
+        data_part = data_payload["result"]["task"]["artifacts"][0]["parts"][0]
+        self.assertEqual(self._assert_part(data_part), "data")
+        self.assertEqual(data_part["data"], {"question": "structured"})
+        self.assertEqual(data_part["mediaType"], "application/json")
 
-        file_payload = self._read_rpc(
+        raw_payload = self._read_rpc(
             "SendMessage",
             {
                 "message": {
@@ -286,21 +340,51 @@ class ServerTests(unittest.TestCase):
                     "role": "ROLE_USER",
                     "parts": [
                         {
-                            "file": {
-                                "fileWithUri": "https://example.test/doc.txt",
-                                "name": "doc.txt",
-                                "mediaType": "text/plain",
-                            }
+                            "raw": "aGVsbG8=",
+                            "filename": "doc.txt",
+                            "mediaType": "text/plain",
                         }
                     ],
                 }
             },
         )
-        file_artifact = file_payload["result"]["task"]["artifacts"][0]["parts"][0]["file"][
-            "fileWithUri"
-        ]
-        self.assertIn("https://example.test/doc.txt", file_artifact)
-        self.assertIn("mediaType=text/plain", file_artifact)
+        raw_part = raw_payload["result"]["task"]["artifacts"][0]["parts"][0]
+        self.assertEqual(self._assert_part(raw_part), "text")
+        self.assertIn("raw: aGVsbG8=", raw_part["text"])
+        self.assertIn("filename=doc.txt", raw_part["text"])
+
+        url_payload = self._read_rpc(
+            "SendMessage",
+            {
+                "message": {
+                    "messageId": str(uuid4()),
+                    "role": "ROLE_USER",
+                    "parts": [
+                        {
+                            "url": "https://example.test/doc.txt",
+                            "filename": "doc.txt",
+                            "mediaType": "text/plain",
+                        }
+                    ],
+                }
+            },
+        )
+        url_part = url_payload["result"]["task"]["artifacts"][0]["parts"][0]
+        self.assertEqual(self._assert_part(url_part), "url")
+        self.assertIn("https://example.test/doc.txt", url_part["url"])
+        self.assertIn("mediaType=text/plain", url_part["url"])
+
+        invalid = self._read_rpc(
+            "SendMessage",
+            {
+                "message": {
+                    "messageId": str(uuid4()),
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hello", "data": {"extra": True}}],
+                }
+            },
+        )
+        self.assertEqual(invalid["error"]["code"], ERROR_INVALID_PARAMS)
 
     def test_list_tasks_status_timestamp_after_parses_offsets(self) -> None:
         payload = self._read_rpc("SendMessage", {"message": self._message("offset filter")})

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -39,7 +39,6 @@ class StoreTests(unittest.TestCase):
                         "taskId": "task-1",
                         "contextId": "ctx-1",
                         "status": {"state": "TASK_STATE_WORKING"},
-                        "final": False,
                     }
                 },
             )
@@ -48,7 +47,6 @@ class StoreTests(unittest.TestCase):
                 "task-1",
                 "cfg-1",
                 {
-                    "name": config_name,
                     "pushNotificationConfig": {
                         "url": "https://callback.test",
                         "token": "token",
@@ -66,5 +64,6 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(stored["id"], "task-1")
         self.assertEqual(seq, 1)
         self.assertEqual(events[0]["statusUpdate"]["status"]["state"], "TASK_STATE_WORKING")
+        self.assertEqual(push["taskId"], "task-1")
         self.assertEqual(push["pushNotificationConfig"]["url"], "https://callback.test")
         self.assertEqual(remote["agentUrl"], "https://agent.test")


### PR DESCRIPTION
## Summary

Normalize the Hermes A2A public protocol surface to the official A2A 1.0 task, message, part, stream response, and request parameter shapes.

Closes #5

## Key Changes

- Use official `TASK_STATE_CANCELED` spelling and remove previous task resource-name request parsing.
- Require strict one-of A2A parts: `text`, `raw`, `url`, or `data`.
- Update task, cancel, subscribe, and outbound client calls to use direct `id` params.
- Update push notification config requests to use `taskId`, config `id`, and plural `ListTaskPushNotificationConfigs`.
- Keep push callbacks as raw `StreamResponse` objects and remove the old status update `final` field.
- Refresh regression tests and docs for the breaking A2A 1.0 surface.

## Verification

- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v` (24 tests passed)
- `git diff --check`