### PR TITLE
fix: align A2A push config wire shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ uv run hermes-a2a card
     publishes an A2A 1.0 AgentCard with the JSON-RPC endpoint in
     `supportedInterfaces`; when `A2A_BEARER_TOKEN` is configured, the card
     advertises the required bearer auth scheme while remaining publicly
-    discoverable.
+    discoverable. Responses include `Cache-Control` and `ETag` headers so
+    clients can cache the card and detect changes.
   - `POST /rpc` for the official A2A 1.0 JSON-RPC methods:
     `SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`,
     `CancelTask`, `SubscribeToTask`, `CreateTaskPushNotificationConfig`,
@@ -143,9 +144,25 @@ The plugin is configured through environment variables:
   such as `message/send` and old task/message/part response fields are not
   supported.
 - Task RPCs use direct task IDs in params such as `{"id": "task-id"}`. Push
-  notification config RPCs use `taskId`, config `id`, and
-  `pushNotificationConfig`; resource-name params such as `tasks/{id}` are not
+  notification config RPCs use the flat A2A 1.0 `TaskPushNotificationConfig`
+  shape with `taskId`, config `id`, `url`, optional `token`, and optional
+  `authentication`; resource-name params such as `tasks/{id}` are not
   supported.
+
+Example push notification config request:
+
+```json
+{
+  "taskId": "task-id",
+  "id": "callback-1",
+  "url": "https://example.com/a2a/push",
+  "token": "task-callback-token",
+  "authentication": {
+    "scheme": "Bearer",
+    "credentials": "secret"
+  }
+}
+```
 - By default the inbound server routes A2A `SendMessage` and
   `SendStreamingMessage` calls through `hermes chat -q ... --quiet`. Set
   `A2A_EXECUTION_ADAPTER=demo` to use the deterministic demo adapter for

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 import urllib.request
@@ -134,8 +135,7 @@ class A2AService:
         return self.adapter.stream(task_id, context_id, message_text, metadata) if stream else self.adapter.continue_task(task_id, context_id, message_text, metadata)
 
     def _notify_push(self, task_id: str, stream_response: dict) -> None:
-        for config in self.store.list_push_configs_for_task(task_id):
-            push_config = config["pushNotificationConfig"]
+        for push_config in self.store.list_push_configs_for_task(task_id):
             payload = json.dumps(stream_response, sort_keys=True).encode("utf-8")
             headers = {"Content-Type": A2A_CONTENT_TYPE}
             auth = push_config.get("authentication") or {}
@@ -221,20 +221,16 @@ class A2AService:
         configured_task_id = str(push_config_wrapper.get("taskId") or "").strip()
         if configured_task_id and configured_task_id != task_id:
             raise ValueError("taskPushNotificationConfig.taskId must be empty or match the task id")
-        push_config = push_config_wrapper.get("pushNotificationConfig")
-        if push_config is None:
-            return
-        if not isinstance(push_config, dict):
-            raise ValueError("taskPushNotificationConfig.pushNotificationConfig must be an object")
-        if not str(push_config.get("url", "")).strip():
-            raise ValueError("pushNotificationConfig.url is required")
-        config_id = str(push_config.get("id") or uuid4()).strip()
-        stored_push_config = dict(push_config)
+        if not str(push_config_wrapper.get("url", "")).strip():
+            raise ValueError("taskPushNotificationConfig.url is required")
+        config_id = str(push_config_wrapper.get("id") or uuid4()).strip()
+        stored_push_config = dict(push_config_wrapper)
+        stored_push_config["taskId"] = task_id
         stored_push_config["id"] = config_id
         self.store.set_push_config(
             task_id,
             config_id,
-            {"pushNotificationConfig": stored_push_config},
+            stored_push_config,
         )
 
     def get_task(self, task_id: str) -> dict:
@@ -320,18 +316,16 @@ class A2AService:
     def create_push_config(self, params: dict) -> dict:
         task_id = _required_string(params, "taskId")
         self.get_task(task_id)
-        push_config = params.get("pushNotificationConfig")
-        if not isinstance(push_config, dict):
-            raise ValueError("pushNotificationConfig is required")
-        if not str(push_config.get("url", "")).strip():
-            raise ValueError("pushNotificationConfig.url is required")
-        config_id = str(push_config.get("id") or uuid4()).strip()
-        stored_push_config = dict(push_config)
+        if not str(params.get("url", "")).strip():
+            raise ValueError("url is required")
+        config_id = str(params.get("id") or uuid4()).strip()
+        stored_push_config = dict(params)
+        stored_push_config["taskId"] = task_id
         stored_push_config["id"] = config_id
         return self.store.set_push_config(
             task_id,
             config_id,
-            {"pushNotificationConfig": stored_push_config},
+            stored_push_config,
         )
 
     def get_push_config(self, params: dict) -> dict:
@@ -406,6 +400,17 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_agent_card(self) -> None:
+        body = json.dumps(self._service.agent_card(), sort_keys=True).encode("utf-8")
+        etag = hashlib.sha256(body).hexdigest()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "public, max-age=300")
+        self.send_header("ETag", f'"{etag}"')
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def _send_stream(self, request_id, stream_responses: Iterable[dict]) -> None:
         self.send_response(HTTPStatus.OK)
         self.send_header("Content-Type", "text/event-stream")
@@ -420,7 +425,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         if parsed.path == "/.well-known/agent-card.json":
             # Discovery is public so clients can learn the agent's advertised
             # transport and security scheme before making authenticated calls.
-            self._send_json(self._service.agent_card())
+            self._send_agent_card()
             return
 
         if not self._require_auth():

--- a/src/hermes_a2a/store.py
+++ b/src/hermes_a2a/store.py
@@ -149,11 +149,11 @@ class SQLiteTaskStore:
     ) -> dict:
         now = utc_timestamp()
         name = push_config_name(task_id, config_id)
-        push_config = dict(config.get("pushNotificationConfig") or config)
-        push_config.setdefault("id", config_id)
-        push_config.setdefault("url", "")
-        push_config.setdefault("token", "")
-        stored = {"taskId": task_id, "pushNotificationConfig": push_config}
+        stored = dict(config)
+        stored["taskId"] = task_id
+        stored["id"] = config_id
+        stored.setdefault("url", "")
+        stored.setdefault("token", "")
         with self._lock, self._conn:
             self._conn.execute(
                 """
@@ -170,8 +170,8 @@ class SQLiteTaskStore:
                     name,
                     task_id,
                     config_id,
-                    str(push_config.get("url", "")),
-                    str(push_config.get("token", "")),
+                    str(stored.get("url", "")),
+                    str(stored.get("token", "")),
                     json.dumps(stored, sort_keys=True),
                     now,
                     now,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -175,6 +175,13 @@ class ServerTests(unittest.TestCase):
             f"{self.server.base_url}/.well-known/agent-card.json", timeout=5
         ) as response:
             card = json.loads(response.read().decode("utf-8"))
+            cache_control = response.getheader("Cache-Control")
+            etag = response.getheader("ETag")
+
+        with urllib.request.urlopen(
+            f"{self.server.base_url}/.well-known/agent-card.json", timeout=5
+        ) as response:
+            repeat_etag = response.getheader("ETag")
 
         self.assertEqual(
             card["supportedInterfaces"],
@@ -191,6 +198,9 @@ class ServerTests(unittest.TestCase):
         self.assertNotIn("protocolVersion", card)
         self.assertNotIn("preferredTransport", card)
         self.assertEqual(card["skills"][0]["inputModes"], ["text/plain", "application/json"])
+        self.assertEqual(cache_control, "public, max-age=300")
+        self.assertTrue(etag)
+        self.assertEqual(repeat_etag, etag)
 
         task_payload = self._read_rpc("SendMessage", {"message": self._message("hello")})
         self.assertEqual(self._assert_one_of(task_payload["result"], ("task", "message")), "task")
@@ -282,6 +292,8 @@ class ServerTests(unittest.TestCase):
 
         cancel_payload = self._read_rpc("CancelTask", {"id": task_id})
         self.assertEqual(cancel_payload["result"]["status"]["state"], "TASK_STATE_CANCELED")
+        terminal_subscribe = self._read_rpc("SubscribeToTask", {"id": task_id})
+        self.assertEqual(terminal_subscribe["error"]["code"], ERROR_UNSUPPORTED_OPERATION)
 
         input_payload = self._read_rpc("SendMessage", {"message": self._message("need input")})
         input_task = input_payload["result"]["task"]
@@ -295,14 +307,12 @@ class ServerTests(unittest.TestCase):
             "CreateTaskPushNotificationConfig",
             {
                 "taskId": task_id,
-                "pushNotificationConfig": {
-                    "id": "cfg-1",
-                    "url": callback_url,
-                    "token": "tok",
-                    "authentication": {
-                        "scheme": "Bearer",
-                        "credentials": "secret",
-                    },
+                "id": "cfg-1",
+                "url": callback_url,
+                "token": "tok",
+                "authentication": {
+                    "scheme": "Bearer",
+                    "credentials": "secret",
                 },
             },
         )
@@ -310,9 +320,12 @@ class ServerTests(unittest.TestCase):
         list_configs = self._read_rpc("ListTaskPushNotificationConfigs", {"taskId": task_id})
 
         self.assertEqual(set_payload["result"]["taskId"], task_id)
-        self.assertEqual(set_payload["result"]["pushNotificationConfig"]["id"], "cfg-1")
-        self.assertEqual(get_payload["result"]["pushNotificationConfig"]["url"], callback_url)
+        self.assertEqual(set_payload["result"]["id"], "cfg-1")
+        self.assertEqual(set_payload["result"]["url"], callback_url)
+        self.assertEqual(set_payload["result"]["token"], "tok")
+        self.assertEqual(get_payload["result"]["url"], callback_url)
         self.assertEqual(len(list_configs["result"]["configs"]), 1)
+        self.assertEqual(list_configs["result"]["configs"][0]["id"], "cfg-1")
         self.assertEqual(list_configs["result"]["nextPageToken"], "")
 
         try:
@@ -352,13 +365,11 @@ class ServerTests(unittest.TestCase):
                     "configuration": {
                         "taskPushNotificationConfig": {
                             "taskId": "",
-                            "pushNotificationConfig": {
-                                "id": "inline",
-                                "url": callback_url,
-                                "authentication": {
-                                    "scheme": "Bearer",
-                                    "credentials": "inline-secret",
-                                },
+                            "id": "inline",
+                            "url": callback_url,
+                            "authentication": {
+                                "scheme": "Bearer",
+                                "credentials": "inline-secret",
                             },
                         }
                     },
@@ -372,7 +383,9 @@ class ServerTests(unittest.TestCase):
         task = payload["result"]["task"]
         stored = self._read_rpc("GetTaskPushNotificationConfig", {"taskId": task["id"], "id": "inline"})
 
-        self.assertEqual(stored["result"]["pushNotificationConfig"]["url"], callback_url)
+        self.assertEqual(stored["result"]["taskId"], task["id"])
+        self.assertEqual(stored["result"]["id"], "inline")
+        self.assertEqual(stored["result"]["url"], callback_url)
         self.assertEqual(callback["content_type"], "application/a2a+json")
         self.assertEqual(callback["authorization"], "Bearer inline-secret")
         self.assertIn("statusUpdate", callback["payload"])
@@ -474,10 +487,16 @@ class ServerTests(unittest.TestCase):
             {"message": self._message("hello")},
             version=None,
         )
+        unsupported_version = self._read_rpc(
+            "SendMessage",
+            {"message": self._message("hello")},
+            version="0.3",
+        )
         legacy = self._read_rpc("message/send", {"message": self._message("hello")})
         extended = self._read_rpc("GetExtendedAgentCard", {})
 
         self.assertEqual(missing_version["error"]["code"], ERROR_VERSION_NOT_SUPPORTED)
+        self.assertEqual(unsupported_version["error"]["code"], ERROR_VERSION_NOT_SUPPORTED)
         self.assertEqual(legacy["error"]["code"], ERROR_METHOD_NOT_FOUND)
         self.assertEqual(extended["error"]["code"], ERROR_UNSUPPORTED_OPERATION)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -47,10 +47,8 @@ class StoreTests(unittest.TestCase):
                 "task-1",
                 "cfg-1",
                 {
-                    "pushNotificationConfig": {
-                        "url": "https://callback.test",
-                        "token": "token",
-                    },
+                    "url": "https://callback.test",
+                    "token": "token",
                 },
             )
             store.set_remote_task("task-1", "https://agent.test", "task-1")
@@ -65,5 +63,7 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(seq, 1)
         self.assertEqual(events[0]["statusUpdate"]["status"]["state"], "TASK_STATE_WORKING")
         self.assertEqual(push["taskId"], "task-1")
-        self.assertEqual(push["pushNotificationConfig"]["url"], "https://callback.test")
+        self.assertEqual(push["id"], "cfg-1")
+        self.assertEqual(push["url"], "https://callback.test")
+        self.assertEqual(push["token"], "token")
         self.assertEqual(remote["agentUrl"], "https://agent.test")


### PR DESCRIPTION
## Summary

Align the A2A 1.0 push notification config wire shape with the current flat `TaskPushNotificationConfig` object and add recommended AgentCard caching headers.

Closes #6.

## Key Changes

- Convert inbound push config create/get/list and inline send-message registration to flat `taskId`/`id`/`url`/`token`/`authentication` payloads in `src/hermes_a2a/server.py`.
- Persist flat push config JSON in `src/hermes_a2a/store.py` so public RPC results no longer return the previous nested wrapper.
- Add deterministic `ETag` and `Cache-Control: public, max-age=300` headers for `/.well-known/agent-card.json`.
- Extend server/store tests for flat config results, inline config registration, unsupported version headers, terminal task subscribe rejection, and AgentCard cache headers.
- Update `README.md` with the breaking flat push config request shape.

## Validation

- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`