### PR TITLE
fix: document A2A version SDK interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,27 @@ The plugin is configured through environment variables:
 
 - JSON-RPC requests must include `A2A-Version: 1.0`. Legacy slash-style methods
   such as `message/send` and old task/message/part response fields are not
-  supported.
+  supported. A missing version header is rejected because this server only
+  advertises A2A 1.0 in its AgentCard `supportedInterfaces`.
+- The official Python SDK `ClientFactory` path sets the A2A version header on
+  its HTTP client. Prefer that path for SDK clients:
+
+  ```python
+  from a2a.client import ClientConfig, ClientFactory
+
+  factory = ClientFactory(ClientConfig(streaming=False))
+  client = await factory.create_from_url("http://127.0.0.1:9999")
+  ```
+
+  If you build raw HTTP requests or instantiate lower-level SDK transports
+  directly, set the header yourself:
+
+  ```python
+  headers = {
+      "Content-Type": "application/json",
+      "A2A-Version": "1.0",
+  }
+  ```
 - Task RPCs use direct task IDs in params such as `{"id": "task-id"}`. Push
   notification config RPCs use the flat A2A 1.0 `TaskPushNotificationConfig`
   shape with `taskId`, config `id`, `url`, optional `token`, and optional

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -499,6 +500,47 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(unsupported_version["error"]["code"], ERROR_VERSION_NOT_SUPPORTED)
         self.assertEqual(legacy["error"]["code"], ERROR_METHOD_NOT_FOUND)
         self.assertEqual(extended["error"]["code"], ERROR_UNSUPPORTED_OPERATION)
+
+    def test_official_sdk_jsonrpc_client_sends_required_version_header(self) -> None:
+        try:
+            import httpx
+            from a2a.client import ClientConfig, ClientFactory
+            from a2a.types.a2a_pb2 import (
+                Message,
+                Part,
+                ROLE_USER,
+                SendMessageRequest,
+                TASK_STATE_COMPLETED,
+            )
+        except ImportError as exc:
+            self.skipTest(f"optional a2a-sdk extra is not installed: {exc}")
+
+        async def run_sdk_request() -> int:
+            http_client = httpx.AsyncClient(trust_env=False)
+            client = await ClientFactory(
+                ClientConfig(streaming=False, httpx_client=http_client)
+            ).create_from_url(
+                self.server.base_url,
+                resolver_http_kwargs={"follow_redirects": False},
+            )
+            try:
+                request = SendMessageRequest(
+                    message=Message(
+                        message_id=str(uuid4()),
+                        role=ROLE_USER,
+                        parts=[Part(text="hello from sdk")],
+                    )
+                )
+                events = [event async for event in client.send_message(request)]
+            finally:
+                await client.close()
+            self.assertEqual(len(events), 1)
+            self.assertTrue(events[0].HasField("task"))
+            return events[0].task.status.state
+
+        state = asyncio.run(run_sdk_request())
+
+        self.assertEqual(state, TASK_STATE_COMPLETED)
 
     def test_outbound_delegate_round_trips_against_local_server(self) -> None:
         env = {


### PR DESCRIPTION
## Summary
Document the A2A-Version requirement for JSON-RPC clients and add a regression test proving the official Python SDK ClientFactory path interoperates with the strict A2A 1.0 server.

Closes #16.

## Key Changes
- Added an optional a2a-sdk integration test that creates a real SDK JSON-RPC client against the local test server and verifies a completed task response.
- Kept the existing missing/unsupported A2A-Version rejection coverage intact.
- Updated README notes to explain why missing A2A-Version is rejected and how SDK/raw HTTP clients should set it.

## Validation
- env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run --extra sdk python -m unittest discover -s tests -v