### PR TITLE
test: cover auth-required task state normalization

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,27 @@
+"""Tests for A2A protocol constants and helpers."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys_path = str(ROOT / "src")
+if sys_path not in os.sys.path:
+    os.sys.path.insert(0, sys_path)
+
+from hermes_a2a.protocol import TASK_STATE_AUTH_REQUIRED, normalize_task_state
+
+
+class ProtocolTests(unittest.TestCase):
+    def test_auth_required_state_normalization_uses_a2a_1_0_constant(self) -> None:
+        self.assertEqual(TASK_STATE_AUTH_REQUIRED, "TASK_STATE_AUTH_REQUIRED")
+        self.assertEqual(
+            normalize_task_state("auth-required"),
+            "TASK_STATE_AUTH_REQUIRED",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds regression coverage for the A2A `auth-required` task-state normalization path so it stays aligned with the official A2A 1.0 `TASK_STATE_AUTH_REQUIRED` wire value.

Closes #15

## Key Changes
- Adds `tests/test_protocol.py` to cover protocol constants and helpers.
- Verifies `TASK_STATE_AUTH_REQUIRED` is exactly `TASK_STATE_AUTH_REQUIRED`.
- Verifies `normalize_task_state("auth-required")` returns the official A2A 1.0 task-state constant.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`