### PR TITLE
fix: clarify reliable a2a cli entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,23 @@ Then restart Hermes and verify the plugin is visible:
 hermes plugins list
 ```
 
-If your Hermes version supports top-level CLI commands from standalone plugins,
-you can use:
+Use the plugin-owned console script for CLI operations:
+
+```bash
+uv run hermes-a2a status
+uv run hermes-a2a card
+```
+
+Some Hermes versions may also expose standalone plugin CLI commands at the
+top level after the plugin is enabled:
 
 ```bash
 hermes a2a status
 hermes a2a card
 ```
 
-For Hermes versions that do not yet discover standalone plugin CLI commands, use
-the plugin-owned console script instead:
-
-```bash
-uv run hermes-a2a status
-uv run hermes-a2a card
-```
+Treat `hermes-a2a` as the reliable command until Hermes core exposes
+standalone plugin CLI discovery in your installation.
 
 ## Runtime surfaces
 
@@ -102,12 +104,15 @@ uv run hermes-a2a card
   - `a2a_cancel_task`
   - `a2a_delegate`
 - CLI:
-  - `hermes a2a status`
-  - `hermes a2a card`
-  - `hermes a2a serve`
-  - `hermes a2a agents list`
-  - `hermes a2a task get <id>`
-  - `hermes a2a task cancel <id>`
+  - `hermes-a2a status`
+  - `hermes-a2a card`
+  - `hermes-a2a serve`
+  - `hermes-a2a agents list`
+  - `hermes-a2a task get <id>`
+  - `hermes-a2a task cancel <id>`
+
+  Hermes versions with standalone plugin CLI discovery may additionally support
+  the same commands under `hermes a2a ...`.
 
 ## Config
 

--- a/src/hermes_a2a/cli.py
+++ b/src/hermes_a2a/cli.py
@@ -1,9 +1,8 @@
 """CLI entrypoints for Hermes A2A commands.
 
-Hermes core can call ``setup_argparse()`` for ``hermes a2a ...`` when its
-plugin CLI discovery supports standalone plugins. The package also exposes a
-standalone ``hermes-a2a`` console script so the plugin remains usable with
-Hermes versions that do not yet discover general plugin CLI commands.
+The package exposes ``hermes-a2a`` as its reliable console script. Hermes core
+can also call ``setup_argparse()`` for ``hermes a2a ...`` when its plugin CLI
+discovery supports standalone plugin commands.
 """
 
 from __future__ import annotations
@@ -24,7 +23,7 @@ from .tools import (
 
 
 def handle_cli(args: Namespace) -> None:
-    """Dispatch `hermes a2a ...` commands."""
+    """Dispatch A2A CLI commands."""
     command = getattr(args, "a2a_command", None)
     if command == "status":
         print(json.dumps(get_status_payload(), indent=2, sort_keys=True))
@@ -86,7 +85,7 @@ def handle_cli(args: Namespace) -> None:
         )
         return
 
-    print("Usage: hermes a2a {status|card|serve|agents list|task get|task cancel}")
+    print("Usage: hermes-a2a {status|card|serve|agents list|task get|task cancel}")
 
 
 def setup_argparse(subparser) -> None:

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -109,9 +109,9 @@ class A2AService:
             "local_tasks": len(self.store.list_tasks()),
         }
         payload["message"] = (
-            "Hermes A2A bridge is configured. Start `hermes-a2a serve` "
-            "(or `hermes a2a serve` on Hermes versions with standalone plugin "
-            "CLI discovery) to expose the inbound JSON-RPC + SSE surface."
+            "Hermes A2A bridge is configured. Start the inbound JSON-RPC + SSE "
+            "surface with `hermes-a2a serve`. `hermes a2a serve` only works on "
+            "Hermes versions that expose standalone plugin CLI commands."
         )
         return payload
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -6,6 +6,7 @@ import io
 import json
 import sys
 import unittest
+from argparse import Namespace
 from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
@@ -27,6 +28,18 @@ class CliEntrypointTests(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["plugin"], "a2a")
         self.assertEqual(payload["status"], "ok")
+        self.assertIn("`hermes-a2a serve`", payload["message"])
+        self.assertIn("only works on Hermes versions", payload["message"])
+
+    def test_usage_prefers_standalone_console_script(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            cli.handle_cli(Namespace(a2a_command=None))
+
+        self.assertEqual(
+            stdout.getvalue().strip(),
+            "Usage: hermes-a2a {status|card|serve|agents list|task get|task cancel}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Clarifies that `hermes-a2a` is the reliable CLI entrypoint while `hermes a2a ...` remains conditional on Hermes core plugin CLI discovery.

## Key Changes
- Documents `uv run hermes-a2a ...` as the primary CLI path in README.md.
- Keeps `hermes a2a ...` documented only as an optional Hermes-core-dependent surface.
- Updates status and usage messaging to point users at `hermes-a2a` first.
- Adds regression coverage for the CLI status message and fallback usage output.

Closes #18