### PR TITLE
fix: use advertised A2A JSON-RPC endpoint

### DIFF
--- a/src/hermes_a2a/client.py
+++ b/src/hermes_a2a/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Iterator
 from uuid import uuid4
@@ -16,6 +17,7 @@ from .protocol import (
     METHOD_SEND_MESSAGE,
     METHOD_SEND_STREAMING_MESSAGE,
     PROTOCOL_VERSION,
+    RPC_PATH,
 )
 
 
@@ -59,14 +61,40 @@ class A2AClient:
         self.base_url = base_url.rstrip("/")
         self.headers = headers or {}
         self.timeout = timeout
+        self._jsonrpc_url: str | None = None
+
+    def _resolve_url(self, path_or_url: str) -> str:
+        if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
+            return path_or_url
+        return urllib.parse.urljoin(f"{self.base_url}/", path_or_url.lstrip("/"))
+
+    def _fallback_jsonrpc_url(self) -> str:
+        return self._resolve_url(RPC_PATH)
+
+    def _select_jsonrpc_url(self, card: dict) -> str:
+        for interface in card.get("supportedInterfaces") or []:
+            if not isinstance(interface, dict):
+                continue
+            if (
+                interface.get("protocolBinding") == "JSONRPC"
+                and interface.get("protocolVersion") == PROTOCOL_VERSION
+                and interface.get("url")
+            ):
+                return self._resolve_url(str(interface["url"]))
+        return self._fallback_jsonrpc_url()
+
+    def _jsonrpc_endpoint(self) -> str:
+        if self._jsonrpc_url is None:
+            self.get_agent_card()
+        return self._jsonrpc_url or self._fallback_jsonrpc_url()
 
     def _request(
         self,
-        path: str,
+        path_or_url: str,
         body: dict | None = None,
         accept: str = "application/json",
     ):
-        url = f"{self.base_url}{path}"
+        url = self._resolve_url(path_or_url)
         payload = None
         headers = {"Accept": accept, "A2A-Version": PROTOCOL_VERSION, **self.headers}
         if body is not None:
@@ -85,7 +113,9 @@ class A2AClient:
 
     def get_agent_card(self) -> dict:
         with self._request("/.well-known/agent-card.json") as response:
-            return json.loads(response.read().decode("utf-8"))
+            card = json.loads(response.read().decode("utf-8"))
+        self._jsonrpc_url = self._select_jsonrpc_url(card)
+        return card
 
     def send_message(
         self,
@@ -107,7 +137,7 @@ class A2AClient:
                 },
             },
         }
-        with self._request("/rpc", request) as response:
+        with self._request(self._jsonrpc_endpoint(), request) as response:
             payload = json.loads(response.read().decode("utf-8"))
         if "error" in payload:
             raise A2AClientError(payload["error"]["message"])
@@ -136,7 +166,11 @@ class A2AClient:
                 },
             },
         }
-        with self._request("/rpc", request, accept="text/event-stream") as response:
+        with self._request(
+            self._jsonrpc_endpoint(),
+            request,
+            accept="text/event-stream",
+        ) as response:
             for raw_line in response:
                 line = raw_line.decode("utf-8").strip()
                 if not line:
@@ -154,7 +188,7 @@ class A2AClient:
             "method": METHOD_GET_TASK,
             "params": {"id": task_id},
         }
-        with self._request("/rpc", request) as response:
+        with self._request(self._jsonrpc_endpoint(), request) as response:
             payload = json.loads(response.read().decode("utf-8"))
         if "error" in payload:
             raise A2AClientError(payload["error"]["message"])
@@ -167,7 +201,7 @@ class A2AClient:
             "method": METHOD_CANCEL_TASK,
             "params": {"id": task_id},
         }
-        with self._request("/rpc", request) as response:
+        with self._request(self._jsonrpc_endpoint(), request) as response:
             payload = json.loads(response.read().decode("utf-8"))
         if "error" in payload:
             raise A2AClientError(payload["error"]["message"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,6 +20,7 @@ sys_path = str(ROOT / "src")
 if sys_path not in os.sys.path:
     os.sys.path.insert(0, sys_path)
 
+from hermes_a2a.client import A2AClient
 from hermes_a2a.config import A2APluginConfig
 from hermes_a2a.protocol import (
     ERROR_INVALID_PARAMS,
@@ -515,3 +516,103 @@ class ServerTests(unittest.TestCase):
 
         self.assertEqual(delegated["task"]["status"]["state"], "TASK_STATE_COMPLETED")
         self.assertEqual(refreshed["id"], delegated["task"]["id"])
+
+    def test_outbound_client_uses_jsonrpc_url_from_agent_card(self) -> None:
+        requests = []
+
+        class CustomRpcHandler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+                if self.path != "/.well-known/agent-card.json":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                base_url = f"http://127.0.0.1:{self.server.server_address[1]}"
+                payload = {
+                    "name": "Custom RPC Agent",
+                    "description": "Test agent with a non-default JSON-RPC path.",
+                    "supportedInterfaces": [
+                        {
+                            "url": f"{base_url}/a2a",
+                            "protocolBinding": "JSONRPC",
+                            "protocolVersion": "1.0",
+                        }
+                    ],
+                    "version": "test",
+                    "defaultInputModes": ["text/plain"],
+                    "defaultOutputModes": ["text/plain"],
+                    "capabilities": {"streaming": True},
+                    "skills": [],
+                }
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler API
+                requests.append(self.path)
+                if self.path != "/a2a":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                payload = json.loads(body.decode("utf-8"))
+                task = {
+                    "id": "remote-task",
+                    "contextId": "remote-task",
+                    "status": {"state": "TASK_STATE_COMPLETED"},
+                    "history": [],
+                }
+                if payload["method"] == "SendStreamingMessage":
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": payload["id"],
+                        "result": {"task": task},
+                    }
+                    response_body = f"data: {json.dumps(response)}\n\n".encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(response_body)))
+                    self.end_headers()
+                    self.wfile.write(response_body)
+                    return
+                if payload["method"] == "SendMessage":
+                    result = {"task": task}
+                elif payload["method"] in {"GetTask", "CancelTask"}:
+                    result = task
+                else:
+                    result = None
+                response = {"jsonrpc": "2.0", "id": payload["id"], "result": result}
+                response_body = json.dumps(response).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response_body)))
+                self.end_headers()
+                self.wfile.write(response_body)
+
+            def log_message(self, format, *args):  # noqa: A003 - inherited name
+                del format, args
+
+        custom_server = HTTPServer(("127.0.0.1", 0), CustomRpcHandler)
+        custom_thread = threading.Thread(target=custom_server.serve_forever, daemon=True)
+        custom_thread.start()
+        base_url = f"http://127.0.0.1:{custom_server.server_address[1]}"
+        try:
+            client = A2AClient(base_url)
+            card = client.get_agent_card()
+            sent = client.send_message("hello")
+            streamed = list(client.stream_message("hello"))
+            fetched = client.get_task("remote-task")
+            canceled = client.cancel_task("remote-task")
+        finally:
+            custom_server.shutdown()
+            custom_server.server_close()
+            custom_thread.join(timeout=2)
+
+        self.assertEqual(card["supportedInterfaces"][0]["url"], f"{base_url}/a2a")
+        self.assertEqual(sent["id"], "remote-task")
+        self.assertEqual(streamed[0]["task"]["id"], "remote-task")
+        self.assertEqual(fetched["id"], "remote-task")
+        self.assertEqual(canceled["id"], "remote-task")
+        self.assertEqual(requests, ["/a2a", "/a2a", "/a2a", "/a2a"])


### PR DESCRIPTION
## Summary
- Resolve the outbound A2A JSON-RPC endpoint from the remote AgentCard `supportedInterfaces` entry instead of hardcoding `/rpc`.
- Add regression coverage for remote agents whose JSON-RPC interface is advertised at a non-default path.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`

Closes #17