### PR TITLE
fix: resume Hermes sessions for A2A continuations

### DIFF
--- a/src/hermes_a2a/adapter.py
+++ b/src/hermes_a2a/adapter.py
@@ -112,14 +112,39 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
         lines = [line for line in stdout.splitlines() if not line.startswith("session_id:")]
         return self._truncate("\n".join(lines).strip())
 
-    def _run(self, task_id: str, context_id: str, message: str) -> Iterable[HermesEvent]:
+    def _extract_session_id(self, stdout: str) -> str:
+        for line in stdout.splitlines():
+            label, separator, value = line.partition(":")
+            if not separator:
+                continue
+            if label.strip() in {"session_id", "Session"}:
+                session_id = value.strip()
+                if session_id:
+                    return session_id
+        return ""
+
+    def _session_id_from_metadata(self, metadata: dict | None) -> str:
+        if not isinstance(metadata, dict):
+            return ""
+        return str(metadata.get("hermes_session_id") or "").strip()
+
+    def _run(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        resume_session_id: str = "",
+    ) -> Iterable[HermesEvent]:
         yield HermesEvent(
             kind="status",
             state="working",
             message="Hermes runtime execution started",
             metadata={"task_id": task_id, "context_id": context_id},
         )
-        command = [self.command, "chat", "--quiet", *self.extra_args, "-q", message]
+        command = [self.command, "chat", "--quiet", *self.extra_args]
+        if resume_session_id:
+            command.extend(["--resume", resume_session_id])
+        command.extend(["-q", message])
         try:
             completed = self.runner(
                 command,
@@ -144,7 +169,9 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
             )
             return
 
-        stdout = self._clean_stdout(completed.stdout or "")
+        raw_stdout = completed.stdout or ""
+        hermes_session_id = self._extract_session_id(raw_stdout)
+        stdout = self._clean_stdout(raw_stdout)
         if completed.returncode != 0:
             yield HermesEvent(
                 kind="status",
@@ -170,7 +197,15 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
             kind="status",
             state="completed",
             message="Hermes runtime execution completed",
-            metadata={"task_id": task_id, "context_id": context_id},
+            metadata={
+                "task_id": task_id,
+                "context_id": context_id,
+                **(
+                    {"hermes_session_id": hermes_session_id}
+                    if hermes_session_id
+                    else {}
+                ),
+            },
         )
 
     def start(
@@ -180,8 +215,12 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
         message: str,
         metadata: dict | None = None,
     ) -> Iterable[HermesEvent]:
-        del metadata
-        return self._run(task_id, context_id, message)
+        return self._run(
+            task_id,
+            context_id,
+            message,
+            resume_session_id=self._session_id_from_metadata(metadata),
+        )
 
     def continue_task(
         self,
@@ -190,8 +229,12 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
         message: str,
         metadata: dict | None = None,
     ) -> Iterable[HermesEvent]:
-        del metadata
-        return self._run(task_id, context_id, message)
+        return self._run(
+            task_id,
+            context_id,
+            message,
+            resume_session_id=self._session_id_from_metadata(metadata),
+        )
 
     def stream(
         self,
@@ -200,8 +243,12 @@ class HermesSubprocessExecutionAdapter(HermesExecutionAdapter):
         message: str,
         metadata: dict | None = None,
     ) -> Iterable[HermesEvent]:
-        del metadata
-        return self._run(task_id, context_id, message)
+        return self._run(
+            task_id,
+            context_id,
+            message,
+            resume_session_id=self._session_id_from_metadata(metadata),
+        )
 
     def cancel(
         self,

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -126,13 +126,21 @@ class A2AService:
         stream: bool,
         metadata: dict | None = None,
     ) -> Iterable:
+        metadata = dict(metadata or {})
+        hermes_session = self.store.get_hermes_session(task_id, context_id)
+        if hermes_session:
+            metadata["hermes_session_id"] = hermes_session["hermesSessionId"]
         # Existing tasks represent continuation. Streaming still uses the
         # adapter's streaming method because the transport contract, not task
         # freshness, decides how updates should be delivered to the caller.
         existing = self.store.get_task(task_id)
         if existing is None:
-            return self.adapter.stream(task_id, context_id, message_text, metadata) if stream else self.adapter.start(task_id, context_id, message_text, metadata)
-        return self.adapter.stream(task_id, context_id, message_text, metadata) if stream else self.adapter.continue_task(task_id, context_id, message_text, metadata)
+            if stream:
+                return self.adapter.stream(task_id, context_id, message_text, metadata)
+            return self.adapter.start(task_id, context_id, message_text, metadata)
+        if stream:
+            return self.adapter.stream(task_id, context_id, message_text, metadata)
+        return self.adapter.continue_task(task_id, context_id, message_text, metadata)
 
     def _notify_push(self, task_id: str, stream_response: dict) -> None:
         for push_config in self.store.list_push_configs_for_task(task_id):
@@ -195,6 +203,11 @@ class A2AService:
             stream=stream,
             metadata={"mode": "stream" if stream else "send"},
         ):
+            hermes_session_id = str(
+                adapter_event.metadata.get("hermes_session_id") or ""
+            ).strip()
+            if hermes_session_id:
+                self.store.set_hermes_session(task_id, context_id, hermes_session_id)
             stream_response = apply_hermes_event(task, adapter_event)
             self.store.append_event(task_id, stream_response)
             events.append(stream_response)

--- a/src/hermes_a2a/store.py
+++ b/src/hermes_a2a/store.py
@@ -68,6 +68,17 @@ class SQLiteTaskStore:
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 );
+
+                CREATE TABLE IF NOT EXISTS hermes_sessions (
+                    task_id TEXT PRIMARY KEY,
+                    context_id TEXT NOT NULL,
+                    hermes_session_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_hermes_sessions_context_id
+                    ON hermes_sessions (context_id, updated_at DESC);
                 """
             )
 
@@ -228,6 +239,55 @@ class SQLiteTaskStore:
             "taskId": row["task_id"],
             "agentUrl": row["agent_url"],
             "remoteTaskId": row["remote_task_id"],
+        }
+
+    def set_hermes_session(
+        self,
+        task_id: str,
+        context_id: str,
+        hermes_session_id: str,
+    ) -> None:
+        now = utc_timestamp()
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO hermes_sessions
+                    (task_id, context_id, hermes_session_id, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    context_id = excluded.context_id,
+                    hermes_session_id = excluded.hermes_session_id,
+                    updated_at = excluded.updated_at
+                """,
+                (task_id, context_id, hermes_session_id, now, now),
+            )
+
+    def get_hermes_session(self, task_id: str, context_id: str = "") -> dict | None:
+        row = self._conn.execute(
+            """
+            SELECT task_id, context_id, hermes_session_id
+            FROM hermes_sessions
+            WHERE task_id = ?
+            """,
+            (task_id,),
+        ).fetchone()
+        if row is None and context_id:
+            row = self._conn.execute(
+                """
+                SELECT task_id, context_id, hermes_session_id
+                FROM hermes_sessions
+                WHERE context_id = ?
+                ORDER BY updated_at DESC
+                LIMIT 1
+                """,
+                (context_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "taskId": row["task_id"],
+            "contextId": row["context_id"],
+            "hermesSessionId": row["hermes_session_id"],
         }
 
     def close(self) -> None:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -15,7 +15,11 @@ sys_path = str(ROOT / "src")
 if sys_path not in os.sys.path:
     os.sys.path.insert(0, sys_path)
 
-from hermes_a2a.adapter import HermesSubprocessExecutionAdapter
+from hermes_a2a.adapter import (
+    HermesEvent,
+    HermesExecutionAdapter,
+    HermesSubprocessExecutionAdapter,
+)
 from hermes_a2a.config import A2APluginConfig
 from hermes_a2a.server import A2AService
 
@@ -46,6 +50,38 @@ class HermesSubprocessAdapterTests(unittest.TestCase):
         self.assertEqual(events[1].text, "Hermes says hello")
         self.assertEqual(events[1].metadata["artifact_id"], "hermes-response")
         self.assertEqual(events[-1].state, "completed")
+        self.assertEqual(events[-1].metadata["hermes_session_id"], "abc123")
+
+    def test_continue_task_resumes_stored_hermes_session(self) -> None:
+        completed = mock.Mock(returncode=0, stdout="continued\n", stderr="")
+        adapter = HermesSubprocessExecutionAdapter(
+            command="hermes",
+            runner=mock.Mock(return_value=completed),
+        )
+
+        list(
+            adapter.continue_task(
+                "task-1",
+                "ctx-1",
+                "follow up",
+                metadata={"hermes_session_id": "20260424_101500_abc123"},
+            )
+        )
+
+        adapter.runner.assert_called_once_with(
+            [
+                "hermes",
+                "chat",
+                "--quiet",
+                "--resume",
+                "20260424_101500_abc123",
+                "-q",
+                "follow up",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120.0,
+        )
 
     def test_start_emits_sanitized_failed_status_when_hermes_command_fails(self) -> None:
         completed = mock.Mock(returncode=2, stdout="", stderr="boom with /secret/path")
@@ -118,6 +154,77 @@ class HermesSubprocessAdapterTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "Unsupported A2A_EXECUTION_ADAPTER"):
                 A2AService(config=config)
+
+    def test_service_persists_and_reuses_hermes_session_for_task_continuation(self) -> None:
+        class RecordingAdapter(HermesExecutionAdapter):
+            def __init__(self) -> None:
+                self.continue_metadata = None
+
+            def start(self, task_id, context_id, message, metadata=None):
+                del message, metadata
+                return [
+                    HermesEvent(
+                        kind="status",
+                        state="completed",
+                        message="done",
+                        metadata={
+                            "task_id": task_id,
+                            "context_id": context_id,
+                            "hermes_session_id": "20260424_101500_abc123",
+                        },
+                    )
+                ]
+
+            def continue_task(self, task_id, context_id, message, metadata=None):
+                del task_id, context_id, message
+                self.continue_metadata = metadata
+                return [
+                    HermesEvent(kind="status", state="completed", message="continued")
+                ]
+
+            def stream(self, task_id, context_id, message, metadata=None):
+                return self.continue_task(task_id, context_id, message, metadata)
+
+            def cancel(self, task_id, context_id, metadata=None):
+                del task_id, context_id, metadata
+                return []
+
+            def finalize_task(self, task_id, context_id, metadata=None):
+                del task_id, context_id
+                return {"adapter": "recording", "metadata": metadata or {}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = A2APluginConfig(store_path=str(Path(tmpdir) / "state.db"))
+            adapter = RecordingAdapter()
+            service = A2AService(config=config, adapter=adapter)
+            try:
+                task, _ = service.send_message(
+                    {
+                        "message": {
+                            "messageId": "msg-1",
+                            "role": "ROLE_USER",
+                            "parts": [{"text": "hello"}],
+                        }
+                    }
+                )
+                service.send_message(
+                    {
+                        "message": {
+                            "messageId": "msg-2",
+                            "role": "ROLE_USER",
+                            "taskId": task["id"],
+                            "contextId": task["contextId"],
+                            "parts": [{"text": "follow up"}],
+                        }
+                    }
+                )
+            finally:
+                service.close()
+
+        self.assertEqual(
+            adapter.continue_metadata["hermes_session_id"],
+            "20260424_101500_abc123",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -52,11 +52,14 @@ class StoreTests(unittest.TestCase):
                 },
             )
             store.set_remote_task("task-1", "https://agent.test", "task-1")
+            store.set_hermes_session("task-1", "ctx-1", "20260424_101500_abc123")
 
             stored = store.get_task("task-1")
             events = store.list_events("task-1")
             push = store.get_push_config(config_name)
             remote = store.get_remote_task("task-1")
+            hermes_session = store.get_hermes_session("task-1")
+            context_session = store.get_hermes_session("missing-task", "ctx-1")
             store.close()
 
         self.assertEqual(stored["id"], "task-1")
@@ -67,3 +70,5 @@ class StoreTests(unittest.TestCase):
         self.assertEqual(push["url"], "https://callback.test")
         self.assertEqual(push["token"], "token")
         self.assertEqual(remote["agentUrl"], "https://agent.test")
+        self.assertEqual(hermes_session["hermesSessionId"], "20260424_101500_abc123")
+        self.assertEqual(context_session["taskId"], "task-1")


### PR DESCRIPTION
## Summary
Fixes A2A task continuation so Hermes subprocess runs resume the previously captured Hermes CLI session instead of starting a fresh conversation.

Closes #19.

## Key Changes
- Capture Hermes `session_id:` / `Session:` stdout metadata while keeping it out of user-visible artifacts.
- Persist Hermes session IDs in SQLite by A2A task, with context fallback.
- Pass stored session metadata into adapter continuations and invoke `hermes chat --resume <session-id>` on subsequent messages.
- Add regression tests for adapter command construction, service continuation wiring, and store persistence.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`