### PR TITLE
fix: publish A2A security requirements

### DIFF
--- a/src/hermes_a2a/mapping.py
+++ b/src/hermes_a2a/mapping.py
@@ -245,7 +245,7 @@ def build_agent_card(config: A2APluginConfig) -> dict:
                 }
             }
         }
-        card["security"] = [{"bearerAuth": []}]
+        card["securityRequirements"] = [{"schemes": {"bearerAuth": []}}]
     return card
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -214,6 +214,12 @@ class ServerTests(unittest.TestCase):
         self._assert_task(task)
 
     def test_bearer_agent_card_remains_public_and_declares_security(self) -> None:
+        try:
+            from a2a.types.a2a_pb2 import AgentCard
+            from google.protobuf.json_format import ParseDict
+        except ImportError as exc:
+            self.skipTest(f"a2a-sdk protobuf parser unavailable: {exc}")
+
         config = A2APluginConfig(
             host="127.0.0.1",
             port=0,
@@ -240,7 +246,9 @@ class ServerTests(unittest.TestCase):
                     }
                 },
             )
-            self.assertEqual(card["security"], [{"bearerAuth": []}])
+            self.assertNotIn("security", card)
+            self.assertEqual(card["securityRequirements"], [{"schemes": {"bearerAuth": []}}])
+            ParseDict(card, AgentCard(), ignore_unknown_fields=False)
 
             payload = json.dumps(
                 {


### PR DESCRIPTION
## Summary
Fixes the authenticated AgentCard shape so bearer-auth cards use the A2A 1.0 `securityRequirements` field instead of the invalid OpenAPI-style `security` field.

Closes #14

## Key Changes
- Updated `build_agent_card()` to publish `securityRequirements` with a `schemes` map for bearer auth.
- Added a regression test that strict-parses the authenticated AgentCard with the installed `a2a-sdk` protobuf parser.
- Preserved the public unauthenticated AgentCard endpoint and bearer auth enforcement behavior.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run --extra sdk python -m unittest discover -s tests -v`
- `git diff --check`