### PR TITLE
fix: raise default a2a timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The plugin is configured through environment variables:
 - `A2A_BEARER_TOKEN`
 - `A2A_EXPORTED_SKILLS`
 - `A2A_REMOTE_AGENTS_JSON`
+- `A2A_DEFAULT_TIMEOUT_SECONDS` (`120` by default for Hermes runtime and
+  outbound A2A calls)
 - `A2A_EXECUTION_ADAPTER` (`hermes` by default, set to `demo` for deterministic protocol testing)
 - `A2A_HERMES_COMMAND` (`hermes` by default)
 - `A2A_HERMES_EXTRA_ARGS` (optional shell-style arguments appended to `hermes chat`)
@@ -167,6 +169,9 @@ Example push notification config request:
   `SendStreamingMessage` calls through `hermes chat -q ... --quiet`. Set
   `A2A_EXECUTION_ADAPTER=demo` to use the deterministic demo adapter for
   protocol testing without invoking a model.
+- The default runtime timeout is 120 seconds. Override it with
+  `A2A_DEFAULT_TIMEOUT_SECONDS` when a deployment needs shorter or longer model
+  execution and remote-agent request windows.
 - The Hermes subprocess adapter is synchronous: streaming endpoints emit A2A
   JSON-RPC SSE `data:` frames after the underlying Hermes CLI call returns.
 - The SQLite store is durable by default and keeps official A2A task snapshots,

--- a/src/hermes_a2a/config.py
+++ b/src/hermes_a2a/config.py
@@ -9,6 +9,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+
 def _truthy(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
@@ -36,7 +39,7 @@ class A2APluginConfig:
     store_path: str = ""
     exported_skills: list[str] = field(default_factory=list)
     remote_agents: list[RemoteAgentPreset] = field(default_factory=list)
-    default_timeout_seconds: float = 10.0
+    default_timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
     allow_runtime_write: bool = True
     execution_adapter: str = "hermes"
     hermes_command: str = "hermes"
@@ -85,6 +88,7 @@ class A2APluginConfig:
                     for agent in self.remote_agents
                 ],
                 "execution_adapter": self.execution_adapter,
+                "default_timeout_seconds": self.default_timeout_seconds,
                 "hermes_command": self.hermes_command,
                 "hermes_extra_args": list(self.hermes_extra_args),
             },
@@ -156,7 +160,8 @@ def load_config() -> A2APluginConfig:
         exported_skills=exported_skills,
         remote_agents=remote_agents,
         default_timeout_seconds=float(
-            os.getenv("A2A_DEFAULT_TIMEOUT_SECONDS", "10").strip() or "10"
+            os.getenv("A2A_DEFAULT_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS)).strip()
+            or str(DEFAULT_TIMEOUT_SECONDS)
         ),
         allow_runtime_write=_truthy(os.getenv("A2A_ALLOW_RUNTIME_WRITE", "true")),
         execution_adapter=execution_adapter,

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -107,8 +107,13 @@ class HermesSubprocessAdapterTests(unittest.TestCase):
             service = A2AService(config=config)
             try:
                 self.assertIsInstance(service.adapter, HermesSubprocessExecutionAdapter)
+                self.assertEqual(
+                    service.adapter.timeout_seconds,
+                    config.default_timeout_seconds,
+                )
             finally:
                 service.close()
+
     def test_service_rejects_unknown_execution_adapter(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = A2APluginConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,12 @@ from hermes_a2a.config import load_config
 
 
 class ConfigTests(unittest.TestCase):
+    def test_load_config_defaults_to_runtime_timeout(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            config = load_config()
+
+        self.assertEqual(config.default_timeout_seconds, 120.0)
+
     def test_load_config_parses_remote_agents_and_allowlist(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.dict(
@@ -49,6 +55,7 @@ class ConfigTests(unittest.TestCase):
                 "A2A_EXECUTION_ADAPTER": "hermes",
                 "A2A_HERMES_COMMAND": "/opt/bin/hermes",
                 "A2A_HERMES_EXTRA_ARGS": "--model test-model --provider test-provider",
+                "A2A_DEFAULT_TIMEOUT_SECONDS": "45.5",
             },
             clear=True,
         ):
@@ -60,3 +67,4 @@ class ConfigTests(unittest.TestCase):
             config.hermes_extra_args,
             ["--model", "test-model", "--provider", "test-provider"],
         )
+        self.assertEqual(config.default_timeout_seconds, 45.5)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -33,6 +33,7 @@ class ToolTests(unittest.TestCase):
         self.assertEqual(payload["plugin"], "a2a")
         self.assertEqual(payload["status"], "ok")
         self.assertFalse(payload["config"]["bearer_token_present"])
+        self.assertEqual(payload["config"]["default_timeout_seconds"], 120.0)
         self.assertEqual(payload["config"]["remote_agents"], [])
 
     def test_status_payload_reflects_environment(self) -> None:


### PR DESCRIPTION
## Summary
Raise the default A2A runtime timeout from 10 seconds to 120 seconds so the configured Hermes subprocess adapter matches realistic model/task execution windows.

Closes #22

## Key Changes
- Add a shared `DEFAULT_TIMEOUT_SECONDS = 120.0` config default and use it for `A2A_DEFAULT_TIMEOUT_SECONDS` fallback.
- Surface the effective timeout in `a2a_status`/status payload config output.
- Document `A2A_DEFAULT_TIMEOUT_SECONDS` and the 120-second default in the README.
- Add regression coverage for the default, env override, status output, and service-to-adapter timeout wiring.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`