### PR TITLE
fix: stream A2A events as they are produced

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ Example push notification config request:
   `SendStreamingMessage` calls through `hermes chat -q ... --quiet`. Set
   `A2A_EXECUTION_ADAPTER=demo` to use the deterministic demo adapter for
   protocol testing without invoking a model.
-- The Hermes subprocess adapter is synchronous: streaming endpoints emit A2A
-  JSON-RPC SSE `data:` frames after the underlying Hermes CLI call returns.
+- The Hermes subprocess adapter starts streaming immediately with a task status
+  update, then emits the final Hermes CLI output after `hermes chat` returns.
+  It does not yet stream individual model tokens from the Hermes CLI.
 - The SQLite store is durable by default and keeps official A2A task snapshots,
   StreamResponse event payloads, remote delegation tracking, and named inbound
   push notification config state.

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -154,11 +154,7 @@ class A2AService:
                 # Push delivery is best-effort. The event remains durable in SQLite.
                 continue
 
-    def send_message(
-        self,
-        params: dict,
-        stream: bool = False,
-    ) -> tuple[dict, list[dict]]:
+    def _prepare_message_task(self, params: dict) -> tuple[dict, str, str, str]:
         message = params.get("message")
         message_text = extract_text_from_message(message)
         if not isinstance(message, dict):
@@ -184,6 +180,30 @@ class A2AService:
         else:
             task.setdefault("history", []).append(message)
         self._configure_push_from_send_message(task_id, params.get("configuration") or {})
+        return task, task_id, context_id, message_text
+
+    def _record_adapter_event(self, task: dict, task_id: str, adapter_event) -> dict:
+        stream_response = apply_hermes_event(task, adapter_event)
+        self.store.append_event(task_id, stream_response)
+        self._notify_push(task_id, stream_response)
+        return stream_response
+
+    def _finalize_message_task(self, task: dict, task_id: str, context_id: str) -> None:
+        adapter_metadata = self.adapter.finalize_task(task_id, context_id)
+        task.setdefault("metadata", {}).update(
+            {
+                "adapter": adapter_metadata.get("adapter", "unknown"),
+                "adapterMetadata": adapter_metadata.get("metadata", {}),
+            }
+        )
+        self.store.upsert_task(task, direction="inbound")
+
+    def send_message(
+        self,
+        params: dict,
+        stream: bool = False,
+    ) -> tuple[dict, list[dict]]:
+        task, task_id, context_id, message_text = self._prepare_message_task(params)
         events: list[dict] = []
 
         # Persist each mapped event before push delivery. If a callback fails,
@@ -195,20 +215,35 @@ class A2AService:
             stream=stream,
             metadata={"mode": "stream" if stream else "send"},
         ):
-            stream_response = apply_hermes_event(task, adapter_event)
-            self.store.append_event(task_id, stream_response)
+            stream_response = self._record_adapter_event(task, task_id, adapter_event)
             events.append(stream_response)
-            self._notify_push(task_id, stream_response)
 
-        adapter_metadata = self.adapter.finalize_task(task_id, context_id)
-        task.setdefault("metadata", {}).update(
-            {
-                "adapter": adapter_metadata.get("adapter", "unknown"),
-                "adapterMetadata": adapter_metadata.get("metadata", {}),
-            }
-        )
-        self.store.upsert_task(task, direction="inbound")
+        self._finalize_message_task(task, task_id, context_id)
         return task, events
+
+    def stream_message(self, params: dict) -> Iterable[dict]:
+        task, task_id, context_id, message_text = self._prepare_message_task(params)
+
+        def stream_responses() -> Iterable[dict]:
+            finalized = False
+            try:
+                for adapter_event in self._iter_adapter_events(
+                    task_id,
+                    context_id,
+                    message_text,
+                    stream=True,
+                    metadata={"mode": "stream"},
+                ):
+                    yield self._record_adapter_event(task, task_id, adapter_event)
+
+                self._finalize_message_task(task, task_id, context_id)
+                finalized = True
+                yield {"task": task}
+            finally:
+                if not finalized:
+                    self._finalize_message_task(task, task_id, context_id)
+
+        return stream_responses()
 
     def _configure_push_from_send_message(self, task_id: str, configuration: dict) -> None:
         if not isinstance(configuration, dict):
@@ -417,8 +452,11 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-cache")
         self.end_headers()
         for stream_response in stream_responses:
-            self.wfile.write(make_sse_payload(jsonrpc_success(request_id, stream_response)))
-            self.wfile.flush()
+            try:
+                self.wfile.write(make_sse_payload(jsonrpc_success(request_id, stream_response)))
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                return
 
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
         parsed = urlparse(self.path)
@@ -477,8 +515,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
                 return
 
             if method == METHOD_SEND_STREAMING_MESSAGE:
-                task, events = self._service.send_message(params, stream=True)
-                self._send_stream(request_id, [*events, {"task": task}])
+                self._send_stream(request_id, self._service.stream_message(params))
                 return
 
             if method == METHOD_GET_TASK:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,6 +20,7 @@ sys_path = str(ROOT / "src")
 if sys_path not in os.sys.path:
     os.sys.path.insert(0, sys_path)
 
+from hermes_a2a.adapter import HermesEvent, HermesExecutionAdapter
 from hermes_a2a.config import A2APluginConfig
 from hermes_a2a.protocol import (
     ERROR_INVALID_PARAMS,
@@ -30,6 +31,98 @@ from hermes_a2a.protocol import (
 )
 from hermes_a2a.server import create_server
 from hermes_a2a.tools import tool_a2a_delegate, tool_a2a_get_task
+
+
+class BlockingStreamAdapter(HermesExecutionAdapter):
+    def __init__(self) -> None:
+        self.first_event_yielded = threading.Event()
+        self.release = threading.Event()
+
+    def _events(self, task_id: str, context_id: str) -> list[HermesEvent]:
+        return [
+            HermesEvent(
+                kind="status",
+                state="working",
+                message="blocking adapter started",
+                metadata={"task_id": task_id, "context_id": context_id},
+            ),
+            HermesEvent(
+                kind="artifact",
+                state="working",
+                message="blocking adapter output emitted",
+                text="finished",
+                metadata={"artifact_id": "blocking-output"},
+            ),
+            HermesEvent(
+                kind="status",
+                state="completed",
+                message="blocking adapter completed",
+                metadata={"task_id": task_id, "context_id": context_id},
+            ),
+        ]
+
+    def start(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        metadata: dict | None = None,
+    ):
+        del message, metadata
+        return self._events(task_id, context_id)
+
+    def continue_task(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        metadata: dict | None = None,
+    ):
+        del message, metadata
+        return self._events(task_id, context_id)
+
+    def stream(
+        self,
+        task_id: str,
+        context_id: str,
+        message: str,
+        metadata: dict | None = None,
+    ):
+        del message, metadata
+        events = self._events(task_id, context_id)
+        self.first_event_yielded.set()
+        yield events[0]
+        self.release.wait(timeout=5)
+        yield from events[1:]
+
+    def cancel(
+        self,
+        task_id: str,
+        context_id: str,
+        metadata: dict | None = None,
+    ):
+        del metadata
+        return [
+            HermesEvent(
+                kind="status",
+                state="canceled",
+                message="blocking adapter canceled",
+                metadata={"task_id": task_id, "context_id": context_id},
+            )
+        ]
+
+    def finalize_task(
+        self,
+        task_id: str,
+        context_id: str,
+        metadata: dict | None = None,
+    ) -> dict:
+        return {
+            "taskId": task_id,
+            "contextId": context_id,
+            "adapter": "blocking",
+            "metadata": metadata or {},
+        }
 
 
 class ServerTests(unittest.TestCase):
@@ -76,6 +169,27 @@ class ServerTests(unittest.TestCase):
             headers["A2A-Version"] = version
         request = urllib.request.Request(
             f"{self.server.base_url}/rpc",
+            data=payload,
+            headers=headers,
+        )
+        return urllib.request.urlopen(request, timeout=5)
+
+    def _rpc_to_server(
+        self,
+        base_url: str,
+        method: str,
+        params: dict,
+        accept: str = "application/json",
+        version: str | None = PROTOCOL_VERSION,
+    ):
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "id": "test", "method": method, "params": params}
+        ).encode("utf-8")
+        headers = {"Content-Type": "application/json", "Accept": accept}
+        if version is not None:
+            headers["A2A-Version"] = version
+        request = urllib.request.Request(
+            f"{base_url}/rpc",
             data=payload,
             headers=headers,
         )
@@ -197,6 +311,7 @@ class ServerTests(unittest.TestCase):
         self.assertNotIn("protocolVersions", card)
         self.assertNotIn("protocolVersion", card)
         self.assertNotIn("preferredTransport", card)
+        self.assertTrue(card["capabilities"]["streaming"])
         self.assertEqual(card["skills"][0]["inputModes"], ["text/plain", "application/json"])
         self.assertEqual(cache_control, "public, max-age=300")
         self.assertTrue(etag)
@@ -354,6 +469,54 @@ class ServerTests(unittest.TestCase):
             {"taskId": task_id, "id": "cfg-1"},
         )
         self.assertIsNone(delete_payload["result"])
+
+    def test_send_streaming_message_flushes_events_before_adapter_finishes(self) -> None:
+        adapter = BlockingStreamAdapter()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = A2APluginConfig(
+                host="127.0.0.1",
+                port=0,
+                store_path=str(Path(tmpdir) / "stream.db"),
+                execution_adapter="demo",
+            )
+            server = create_server(config=config, adapter=adapter)
+            server.start()
+            first_line: dict[str, str] = {}
+            first_line_read = threading.Event()
+            client_error: list[BaseException] = []
+
+            def read_first_stream_line() -> None:
+                try:
+                    with self._rpc_to_server(
+                        server.base_url,
+                        "SendStreamingMessage",
+                        {"message": self._message("slow hello")},
+                        accept="text/event-stream",
+                    ) as response:
+                        first_line["content_type"] = response.headers.get_content_type()
+                        first_line["line"] = response.readline().decode("utf-8")
+                        first_line_read.set()
+                        response.read()
+                except BaseException as exc:  # pragma: no cover - failure diagnostics
+                    client_error.append(exc)
+
+            client = threading.Thread(target=read_first_stream_line)
+            client.start()
+            try:
+                self.assertTrue(adapter.first_event_yielded.wait(timeout=2))
+                self.assertTrue(
+                    first_line_read.wait(timeout=0.5),
+                    "first SSE frame stayed buffered until task completion",
+                )
+                self.assertFalse(client_error)
+                self.assertEqual(first_line["content_type"], "text/event-stream")
+                self.assertTrue(first_line["line"].startswith("data: "))
+                payload = json.loads(first_line["line"].split(":", 1)[1].strip())
+                self.assertIn("statusUpdate", payload["result"])
+            finally:
+                adapter.release.set()
+                client.join(timeout=2)
+                server.stop()
 
     def test_send_message_configuration_registers_push_config(self) -> None:
         callback, callback_url, callback_server, callback_thread = self._start_callback_server()


### PR DESCRIPTION
## Summary

Fixes SendStreamingMessage buffering so SSE responses are written as adapter events are produced instead of after the task finishes.

Closes #20

## Key Changes

- Split message task preparation, event recording, and finalization in src/hermes_a2a/server.py so streaming and non-streaming paths share lifecycle handling.
- Route SendStreamingMessage through a live service iterator and flush each SSE data frame immediately.
- Finalize task snapshots even when a streaming client disconnects early.
- Add a blocking adapter regression test that proves the first SSE frame arrives before adapter completion.
- Keep AgentCard streaming capability covered and update README wording for subprocess adapter behavior.

## Validation

- env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v
- git diff --check
- env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m py_compile src/hermes_a2a/server.py tests/test_server.py