### PR TITLE
fix: cancel active streaming tasks

### DIFF
--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -49,6 +49,7 @@ from .protocol import (
     METHOD_SEND_STREAMING_MESSAGE,
     METHOD_SUBSCRIBE_TO_TASK,
     PROTOCOL_VERSION,
+    TASK_STATE_CANCELED,
     TERMINAL_TASK_STATES,
     decode_page_token,
     decode_task_page_token,
@@ -197,11 +198,15 @@ class A2AService:
         if hermes_session_id:
             self.store.set_hermes_session(task_id, task["contextId"], hermes_session_id)
         stream_response = apply_hermes_event(task, adapter_event)
+        self.store.upsert_task(task, direction="inbound")
         self.store.append_event(task_id, stream_response)
         self._notify_push(task_id, stream_response)
         return stream_response
 
-    def _finalize_message_task(self, task: dict, task_id: str, context_id: str) -> None:
+    def _finalize_message_task(self, task: dict, task_id: str, context_id: str) -> dict:
+        latest = self.store.get_task(task_id)
+        if latest and latest.get("status", {}).get("state") == TASK_STATE_CANCELED:
+            task = latest
         adapter_metadata = self.adapter.finalize_task(task_id, context_id)
         task.setdefault("metadata", {}).update(
             {
@@ -210,6 +215,7 @@ class A2AService:
             }
         )
         self.store.upsert_task(task, direction="inbound")
+        return task
 
     def send_message(
         self,
@@ -231,13 +237,15 @@ class A2AService:
             stream_response = self._record_adapter_event(task, task_id, adapter_event)
             events.append(stream_response)
 
-        self._finalize_message_task(task, task_id, context_id)
+        task = self._finalize_message_task(task, task_id, context_id)
         return task, events
 
     def stream_message(self, params: dict) -> Iterable[dict]:
         task, task_id, context_id, message_text = self._prepare_message_task(params)
+        self.store.upsert_task(task, direction="inbound")
 
         def stream_responses() -> Iterable[dict]:
+            nonlocal task
             finalized = False
             try:
                 for adapter_event in self._iter_adapter_events(
@@ -249,7 +257,7 @@ class A2AService:
                 ):
                     yield self._record_adapter_event(task, task_id, adapter_event)
 
-                self._finalize_message_task(task, task_id, context_id)
+                task = self._finalize_message_task(task, task_id, context_id)
                 finalized = True
                 yield {"task": task}
             finally:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,6 +39,8 @@ class BlockingStreamAdapter(HermesExecutionAdapter):
     def __init__(self) -> None:
         self.first_event_yielded = threading.Event()
         self.release = threading.Event()
+        self.canceled = threading.Event()
+        self.cancel_calls: list[tuple[str, str]] = []
 
     def _events(self, task_id: str, context_id: str) -> list[HermesEvent]:
         return [
@@ -94,7 +96,11 @@ class BlockingStreamAdapter(HermesExecutionAdapter):
         events = self._events(task_id, context_id)
         self.first_event_yielded.set()
         yield events[0]
-        self.release.wait(timeout=5)
+        while not self.release.wait(timeout=0.05):
+            if self.canceled.is_set():
+                return
+        if self.canceled.is_set():
+            return
         yield from events[1:]
 
     def cancel(
@@ -104,6 +110,8 @@ class BlockingStreamAdapter(HermesExecutionAdapter):
         metadata: dict | None = None,
     ):
         del metadata
+        self.cancel_calls.append((task_id, context_id))
+        self.canceled.set()
         return [
             HermesEvent(
                 kind="status",
@@ -527,6 +535,71 @@ class ServerTests(unittest.TestCase):
                 adapter.release.set()
                 client.join(timeout=2)
                 server.stop()
+
+    def test_cancel_task_finds_active_streaming_task_before_finalization(self) -> None:
+        adapter = BlockingStreamAdapter()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = A2APluginConfig(
+                host="127.0.0.1",
+                port=0,
+                store_path=str(Path(tmpdir) / "cancel-stream.db"),
+                execution_adapter="demo",
+            )
+            server = create_server(config=config, adapter=adapter)
+            server.start()
+            first_payload: dict[str, dict] = {}
+            first_line_read = threading.Event()
+            client_error: list[BaseException] = []
+
+            def read_stream() -> None:
+                try:
+                    with self._rpc_to_server(
+                        server.base_url,
+                        "SendStreamingMessage",
+                        {"message": self._message("cancel me while streaming")},
+                        accept="text/event-stream",
+                    ) as response:
+                        line = response.readline().decode("utf-8")
+                        first_payload["event"] = json.loads(line.split(":", 1)[1].strip())
+                        first_line_read.set()
+                        response.read()
+                except BaseException as exc:  # pragma: no cover - failure diagnostics
+                    client_error.append(exc)
+
+            client = threading.Thread(target=read_stream)
+            client.start()
+            try:
+                self.assertTrue(adapter.first_event_yielded.wait(timeout=2))
+                self.assertTrue(first_line_read.wait(timeout=2))
+                task_id = first_payload["event"]["result"]["statusUpdate"]["taskId"]
+
+                with self._rpc_to_server(
+                    server.base_url,
+                    "CancelTask",
+                    {"id": task_id},
+                ) as response:
+                    cancel_payload = json.loads(response.read().decode("utf-8"))
+
+                self.assertNotIn("error", cancel_payload)
+                self.assertEqual(
+                    cancel_payload["result"]["status"]["state"],
+                    "TASK_STATE_CANCELED",
+                )
+                self.assertEqual(adapter.cancel_calls, [(task_id, task_id)])
+                client.join(timeout=2)
+                self.assertFalse(client.is_alive())
+                with self._rpc_to_server(server.base_url, "GetTask", {"id": task_id}) as response:
+                    stored_payload = json.loads(response.read().decode("utf-8"))
+                self.assertEqual(
+                    stored_payload["result"]["status"]["state"],
+                    "TASK_STATE_CANCELED",
+                )
+            finally:
+                adapter.release.set()
+                client.join(timeout=2)
+                server.stop()
+
+            self.assertFalse(client_error)
 
     def test_send_message_configuration_registers_push_config(self) -> None:
         callback, callback_url, callback_server, callback_thread = self._start_callback_server()


### PR DESCRIPTION
## Summary
Fixes the public `CancelTask` path for in-flight streaming tasks by making task snapshots visible before streaming finalization and preserving canceled state during final cleanup.

Closes #32

## Key Changes
- Persist the initial streaming task snapshot before adapter execution starts in `src/hermes_a2a/server.py`.
- Refresh the durable task snapshot after each adapter event so `GetTask`, `CancelTask`, and subscriptions see active progress.
- Preserve a concurrently canceled task during stream finalization instead of overwriting it with stale in-memory state.
- Extend the blocking stream test adapter to model cancellation before release.
- Add an end-to-end regression that starts `SendStreamingMessage`, cancels after the first `statusUpdate`, and verifies the stored task remains `TASK_STATE_CANCELED`.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`