### PR TITLE
fix: clarify Hermes streaming capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ Example push notification config request:
 - The Hermes subprocess adapter starts streaming immediately with a task status
   update, then emits the final Hermes CLI output after `hermes chat` returns.
   It does not yet stream individual model tokens from the Hermes CLI.
+- The AgentCard keeps the official A2A `streaming: true` capability because
+  `SendStreamingMessage` and `SubscribeToTask` return SSE task events. It also
+  advertises the non-required
+  `https://github.com/caelaxie/hermes_a2a/extensions/runtime-streaming`
+  extension so clients can distinguish task-event streaming from token/tool
+  runtime streaming.
 - The SQLite store is durable by default and keeps official A2A task snapshots,
   StreamResponse event payloads, remote delegation tracking, and named inbound
   push notification config state.

--- a/src/hermes_a2a/mapping.py
+++ b/src/hermes_a2a/mapping.py
@@ -15,6 +15,10 @@ from .protocol import (
     normalize_task_state,
 )
 
+HERMES_RUNTIME_STREAMING_EXTENSION_URI = (
+    "https://github.com/caelaxie/hermes_a2a/extensions/runtime-streaming"
+)
+
 
 def utc_timestamp() -> str:
     """Return an RFC3339 timestamp in UTC."""
@@ -234,6 +238,18 @@ def build_agent_card(config: A2APluginConfig) -> dict:
         "capabilities": {
             "streaming": True,
             "pushNotifications": True,
+            "extensions": [
+                {
+                    "uri": HERMES_RUNTIME_STREAMING_EXTENSION_URI,
+                    "description": (
+                        "SendStreamingMessage streams A2A task status and artifact "
+                        "events. The Hermes subprocess adapter emits task-level "
+                        "progress and the final CLI output, not token- or "
+                        "tool-level Hermes runtime chunks."
+                    ),
+                    "required": False,
+                }
+            ],
         },
         "skills": skills,
     }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -314,6 +314,15 @@ class ServerTests(unittest.TestCase):
         self.assertNotIn("protocolVersion", card)
         self.assertNotIn("preferredTransport", card)
         self.assertTrue(card["capabilities"]["streaming"])
+        streaming_extensions = card["capabilities"].get("extensions", [])
+        self.assertEqual(len(streaming_extensions), 1)
+        self.assertEqual(
+            streaming_extensions[0]["uri"],
+            "https://github.com/caelaxie/hermes_a2a/extensions/runtime-streaming",
+        )
+        self.assertFalse(streaming_extensions[0]["required"])
+        self.assertIn("task-level progress", streaming_extensions[0]["description"])
+        self.assertIn("not token-", streaming_extensions[0]["description"])
         self.assertEqual(card["skills"][0]["inputModes"], ["text/plain", "application/json"])
         self.assertEqual(cache_control, "public, max-age=300")
         self.assertTrue(etag)


### PR DESCRIPTION
## Summary
Closes #33.

Clarifies that the Hermes subprocess adapter supports A2A task-event streaming, while it does not yet expose token/tool-level Hermes runtime chunks from the CLI. The AgentCard now publishes that distinction as a non-required capability extension.

## Key Changes
- Adds a runtime-streaming extension URI to AgentCard capabilities in src/hermes_a2a/mapping.py.
- Keeps official A2A streaming enabled while documenting the Hermes subprocess granularity.
- Adds regression coverage for the AgentCard extension in tests/test_server.py.
- Updates README streaming notes for remote clients.

## Validation
- env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run --extra sdk python -m unittest discover -s tests -v