### PR TITLE
fix: expose a2a plugin cli discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repository is the `a2a` Hermes plugin. It supports two load paths:
 - packaged plugin entry point: `hermes_a2a` from `pyproject.toml`
 - standalone console script: `hermes-a2a` from `src/hermes_a2a/cli.py`
 - directory plugin compatibility from the repo root shims: `__init__.py`,
-  `schemas.py`, and `tools.py`
+  `cli.py`, `schemas.py`, and `tools.py`
 
 Keep real implementation under `src/hermes_a2a/`. Root-level files should stay
 thin compatibility shims unless the Hermes directory-plugin contract requires

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The repo root stays Hermes-compatible, but all real implementation lives in `src
 ```text
 .
 ├── __init__.py
+├── cli.py
 ├── plugin.yaml
 ├── pyproject.toml
 ├── schemas.py
@@ -83,6 +84,15 @@ hermes a2a card
 Treat `hermes-a2a` as the reliable command until Hermes core exposes
 standalone plugin CLI discovery in your installation.
 
+This plugin registers the `a2a` command through both `ctx.register_cli_command`
+and a repo-root `cli.py` compatibility shim. Current Hermes core integration is
+tracked upstream in [NousResearch/hermes-agent#13643](https://github.com/NousResearch/hermes-agent/pull/13643).
+After installing a Hermes build with that support, verify the top-level path:
+
+```bash
+hermes a2a status
+```
+
 ## Runtime surfaces
 
 - Inbound server:
@@ -112,7 +122,9 @@ standalone plugin CLI discovery in your installation.
   - `hermes-a2a task cancel <id>`
 
   Hermes versions with standalone plugin CLI discovery may additionally support
-  the same commands under `hermes a2a ...`.
+  the same commands under `hermes a2a ...`; see
+  [NousResearch/hermes-agent#13643](https://github.com/NousResearch/hermes-agent/pull/13643)
+  for the upstream CLI wiring.
 
 ## Config
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,12 @@
+"""Repo-root CLI shim for Hermes directory-plugin compatibility."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from hermes_a2a.cli import register_cli  # noqa: E402

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,3 +7,5 @@ provides_tools:
   - a2a_get_task
   - a2a_cancel_task
   - a2a_delegate
+provides_cli_commands:
+  - a2a

--- a/src/hermes_a2a/cli.py
+++ b/src/hermes_a2a/cli.py
@@ -112,6 +112,11 @@ def setup_argparse(subparser) -> None:
     subparser.set_defaults(func=handle_cli)
 
 
+def register_cli(subparser) -> None:
+    """Convention-based Hermes CLI hook for directory plugin scanners."""
+    setup_argparse(subparser)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the standalone ``hermes-a2a`` argument parser."""
     parser = argparse.ArgumentParser(

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -6,6 +6,7 @@ import io
 import json
 import sys
 import unittest
+from argparse import ArgumentParser
 from argparse import Namespace
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -40,6 +41,15 @@ class CliEntrypointTests(unittest.TestCase):
             stdout.getvalue().strip(),
             "Usage: hermes-a2a {status|card|serve|agents list|task get|task cancel}",
         )
+
+    def test_register_cli_exposes_same_parser_tree_for_hermes_core(self) -> None:
+        parser = ArgumentParser(prog="hermes a2a")
+
+        cli.register_cli(parser)
+        args = parser.parse_args(["status"])
+
+        self.assertEqual(args.a2a_command, "status")
+        self.assertIs(args.func, cli.handle_cli)
 
 
 if __name__ == "__main__":

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -11,9 +11,11 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import schemas as root_schemas  # noqa: E402
+import cli as root_cli  # noqa: E402
 import tools as root_tools  # noqa: E402
 
 sys.path.insert(0, str(ROOT / "src"))
+from hermes_a2a import cli as pkg_cli  # noqa: E402
 from hermes_a2a import tools as pkg_tools  # noqa: E402
 from hermes_a2a import schemas as pkg_schemas  # noqa: E402
 
@@ -22,4 +24,5 @@ class ShimTests(unittest.TestCase):
     def test_repo_root_exports_packaged_functions(self) -> None:
         self.assertIs(root_tools.tool_a2a_delegate, pkg_tools.tool_a2a_delegate)
         self.assertIs(root_tools.tool_a2a_status, pkg_tools.tool_a2a_status)
+        self.assertIs(root_cli.register_cli, pkg_cli.register_cli)
         self.assertIs(root_schemas.A2A_DELEGATE_SCHEMA, pkg_schemas.A2A_DELEGATE_SCHEMA)


### PR DESCRIPTION
## Summary
Adds the plugin-side CLI discovery hooks needed for top-level `hermes a2a ...` support once Hermes core wires general plugin commands into argparse.

## Key Changes
- Adds a convention-based `register_cli(subparser)` hook that reuses the existing A2A parser setup.
- Adds a repo-root `cli.py` shim for directory-plugin CLI scanners.
- Declares the `a2a` command in `plugin.yaml` metadata.
- Updates README and repo instructions with the upstream Hermes core integration PR.
- Adds regression coverage for the parser hook and root shim export.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest tests.test_cli_entrypoint tests.test_shims -v`
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`

Closes #34