### PR TITLE
fix: document Hermes CLI compatibility gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,39 @@ uv run hermes-a2a status
 uv run hermes-a2a card
 ```
 
-Some Hermes versions may also expose standalone plugin CLI commands at the
-top level after the plugin is enabled:
+Top-level plugin CLI discovery is not available in any released Hermes tag as
+of 2026-04-24. The first known Hermes core support is the unreleased upstream
+PR [NousResearch/hermes-agent#13643](https://github.com/NousResearch/hermes-agent/pull/13643)
+at commit `308bbf6a5480223ec484b342422fe883e8ac81e4`; the latest release
+checked for this note, `v2026.4.23`, does not include it.
+
+After installing a Hermes build that contains that commit, the same commands
+should be available at the top level:
 
 ```bash
 hermes a2a status
 hermes a2a card
 ```
 
-Treat `hermes-a2a` as the reliable command until Hermes core exposes
-standalone plugin CLI discovery in your installation.
+Treat `hermes-a2a` as the reliable fallback on older or released Hermes
+installs.
 
 This plugin registers the `a2a` command through both `ctx.register_cli_command`
-and a repo-root `cli.py` compatibility shim. Current Hermes core integration is
-tracked upstream in [NousResearch/hermes-agent#13643](https://github.com/NousResearch/hermes-agent/pull/13643).
-After installing a Hermes build with that support, verify the top-level path:
+and a repo-root `cli.py` compatibility shim. To verify top-level registration
+in an environment with the required Hermes core support, run:
 
 ```bash
 hermes a2a status
+```
+
+The JSON status payload also reports the current compatibility state under
+`hermes_cli.top_level_cli_discovery`.
+
+The unittest suite includes the same integration check as an opt-in test for
+machines that have a supported Hermes build installed:
+
+```bash
+HERMES_A2A_VERIFY_TOP_LEVEL_CLI=1 uv run python -m unittest tests.test_cli_entrypoint.CliEntrypointTests.test_installed_hermes_exposes_top_level_cli_when_supported -v
 ```
 
 ## Runtime surfaces
@@ -121,10 +136,12 @@ hermes a2a status
   - `hermes-a2a task get <id>`
   - `hermes-a2a task cancel <id>`
 
-  Hermes versions with standalone plugin CLI discovery may additionally support
-  the same commands under `hermes a2a ...`; see
+  Hermes builds containing upstream PR
   [NousResearch/hermes-agent#13643](https://github.com/NousResearch/hermes-agent/pull/13643)
-  for the upstream CLI wiring.
+  at commit `308bbf6a5480223ec484b342422fe883e8ac81e4` may additionally
+  support the same commands under `hermes a2a ...`. No released Hermes tag
+  includes that support as of 2026-04-24, so keep `hermes-a2a` documented for
+  older installs.
 
 ## Config
 

--- a/src/hermes_a2a/config.py
+++ b/src/hermes_a2a/config.py
@@ -10,6 +10,14 @@ from pathlib import Path
 
 
 DEFAULT_TIMEOUT_SECONDS = 120.0
+HERMES_TOP_LEVEL_CLI_MIN_RELEASE: str | None = None
+HERMES_TOP_LEVEL_CLI_MIN_COMMIT = "308bbf6a5480223ec484b342422fe883e8ac81e4"
+HERMES_TOP_LEVEL_CLI_UPSTREAM_PR = "https://github.com/NousResearch/hermes-agent/pull/13643"
+HERMES_TOP_LEVEL_CLI_STATUS_NOTE = (
+    "No released Hermes tag includes standalone plugin CLI discovery as of "
+    "2026-04-24; use hermes-a2a unless your Hermes build contains the upstream "
+    "plugin CLI wiring commit."
+)
 
 
 def _truthy(value: str) -> bool:
@@ -91,6 +99,17 @@ class A2APluginConfig:
                 "default_timeout_seconds": self.default_timeout_seconds,
                 "hermes_command": self.hermes_command,
                 "hermes_extra_args": list(self.hermes_extra_args),
+            },
+            "hermes_cli": {
+                "top_level_command": "hermes a2a",
+                "fallback_command": "hermes-a2a",
+                "top_level_cli_discovery": {
+                    "state": "unreleased-upstream",
+                    "minimum_release": HERMES_TOP_LEVEL_CLI_MIN_RELEASE,
+                    "minimum_commit": HERMES_TOP_LEVEL_CLI_MIN_COMMIT,
+                    "upstream_pr": HERMES_TOP_LEVEL_CLI_UPSTREAM_PR,
+                    "note": HERMES_TOP_LEVEL_CLI_STATUS_NOTE,
+                },
             },
         }
 

--- a/src/hermes_a2a/server.py
+++ b/src/hermes_a2a/server.py
@@ -18,7 +18,7 @@ from .adapter import (
     HermesExecutionAdapter,
     HermesSubprocessExecutionAdapter,
 )
-from .config import A2APluginConfig, load_config
+from .config import A2APluginConfig, HERMES_TOP_LEVEL_CLI_MIN_COMMIT, load_config
 from .mapping import (
     apply_hermes_event,
     build_agent_card,
@@ -112,7 +112,9 @@ class A2AService:
         payload["message"] = (
             "Hermes A2A bridge is configured. Start the inbound JSON-RPC + SSE "
             "surface with `hermes-a2a serve`. `hermes a2a serve` only works on "
-            "Hermes versions that expose standalone plugin CLI commands."
+            "Hermes builds with standalone plugin CLI discovery; no released "
+            "Hermes tag includes that support yet, so use `hermes-a2a` unless "
+            f"your Hermes build contains {HERMES_TOP_LEVEL_CLI_MIN_COMMIT}."
         )
         return payload
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import shutil
+import subprocess
 import sys
 import unittest
 from argparse import ArgumentParser
@@ -30,7 +33,16 @@ class CliEntrypointTests(unittest.TestCase):
         self.assertEqual(payload["plugin"], "a2a")
         self.assertEqual(payload["status"], "ok")
         self.assertIn("`hermes-a2a serve`", payload["message"])
-        self.assertIn("only works on Hermes versions", payload["message"])
+        self.assertIn("no released Hermes tag includes", payload["message"])
+        self.assertEqual(payload["hermes_cli"]["fallback_command"], "hermes-a2a")
+        self.assertEqual(payload["hermes_cli"]["top_level_command"], "hermes a2a")
+        self.assertIsNone(
+            payload["hermes_cli"]["top_level_cli_discovery"]["minimum_release"]
+        )
+        self.assertEqual(
+            payload["hermes_cli"]["top_level_cli_discovery"]["minimum_commit"],
+            "308bbf6a5480223ec484b342422fe883e8ac81e4",
+        )
 
     def test_usage_prefers_standalone_console_script(self) -> None:
         stdout = io.StringIO()
@@ -42,6 +54,16 @@ class CliEntrypointTests(unittest.TestCase):
             "Usage: hermes-a2a {status|card|serve|agents list|task get|task cancel}",
         )
 
+    def test_readme_documents_top_level_cli_compatibility_gate(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("uv run hermes-a2a status", readme)
+        self.assertIn("hermes a2a status", readme)
+        self.assertIn("No released Hermes tag", readme)
+        self.assertIn("v2026.4.23", readme)
+        self.assertIn("308bbf6a5480223ec484b342422fe883e8ac81e4", readme)
+        self.assertIn("HERMES_A2A_VERIFY_TOP_LEVEL_CLI=1", readme)
+
     def test_register_cli_exposes_same_parser_tree_for_hermes_core(self) -> None:
         parser = ArgumentParser(prog="hermes a2a")
 
@@ -50,6 +72,31 @@ class CliEntrypointTests(unittest.TestCase):
 
         self.assertEqual(args.a2a_command, "status")
         self.assertIs(args.func, cli.handle_cli)
+
+    @unittest.skipUnless(
+        os.environ.get("HERMES_A2A_VERIFY_TOP_LEVEL_CLI") == "1",
+        "set HERMES_A2A_VERIFY_TOP_LEVEL_CLI=1 to verify an installed Hermes core",
+    )
+    def test_installed_hermes_exposes_top_level_cli_when_supported(self) -> None:
+        hermes = shutil.which("hermes")
+        if hermes is None:
+            self.skipTest("hermes executable is not on PATH")
+
+        env = os.environ.copy()
+        env.setdefault("A2A_STORE_PATH", ":memory:")
+        result = subprocess.run(
+            [hermes, "a2a", "status"],
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=20,
+        )
+        payload = json.loads(result.stdout)
+
+        self.assertEqual(payload["plugin"], "a2a")
+        self.assertEqual(payload["status"], "ok")
 
 
 if __name__ == "__main__":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,6 +35,16 @@ class ToolTests(unittest.TestCase):
         self.assertFalse(payload["config"]["bearer_token_present"])
         self.assertEqual(payload["config"]["default_timeout_seconds"], 120.0)
         self.assertEqual(payload["config"]["remote_agents"], [])
+        self.assertEqual(payload["hermes_cli"]["fallback_command"], "hermes-a2a")
+        self.assertEqual(payload["hermes_cli"]["top_level_command"], "hermes a2a")
+        self.assertEqual(
+            payload["hermes_cli"]["top_level_cli_discovery"]["state"],
+            "unreleased-upstream",
+        )
+        self.assertEqual(
+            payload["hermes_cli"]["top_level_cli_discovery"]["minimum_commit"],
+            "308bbf6a5480223ec484b342422fe883e8ac81e4",
+        )
 
     def test_status_payload_reflects_environment(self) -> None:
         with mock.patch.dict(


### PR DESCRIPTION
## Summary
- Document that no released Hermes tag currently supports top-level standalone plugin CLI discovery, and identify the first known upstream commit that does.
- Keep `hermes-a2a` documented as the reliable fallback while surfacing compatibility metadata in status output.
- Add regression coverage plus an opt-in integration test for supported Hermes core installs.

## Key Changes
- README documents the unreleased upstream support gate, fallback command, and verification command.
- Status output now includes `hermes_cli.top_level_cli_discovery` metadata with the upstream PR and commit.
- The user-facing status message explains why `hermes a2a ...` may be unavailable.
- CLI/tool tests assert the compatibility note, README contract, and opt-in installed-Hermes check.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run hermes-a2a status`

Closes #39.