### PR TITLE
docs: fix deployment bearer token example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ set `A2A_PUBLIC_BASE_URL` to the external HTTPS origin. Forward both
 `/.well-known/agent-card.json` and `/rpc` to the same local service. The
 AgentCard endpoint intentionally remains publicly discoverable so clients can
 read the bridge URL, protocol version, and advertised security scheme. When
-`A2A_BEARER_TOKEN` is set, `/rpc` requires `Authorization: Bearer ...`.
+`A2A_BEARER_TOKEN` is set, `/rpc` requires `Authorization: Bearer $TOKEN`.
 Preserve the `Authorization` and `A2A-Version` headers, allow request durations
 at least as long as `A2A_DEFAULT_TIMEOUT_SECONDS`, and disable response
 buffering for SSE calls to `SendStreamingMessage` and `SubscribeToTask`.

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,41 @@
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+
+def _readme_text() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+class ReadmeDeploymentExampleTests(unittest.TestCase):
+    def test_bearer_token_guidance_uses_the_deployment_token_variable(self):
+        text = _readme_text()
+
+        self.assertIn("`Authorization: Bearer $TOKEN`", text)
+        self.assertIn("TOKEN=replace-with-a-long-random-token", text)
+        self.assertIn('-H "Authorization: Bearer $TOKEN"', text)
+        self.assertNotIn("Authorization: Bearer ***", text)
+
+    def test_bash_fenced_blocks_are_shell_syntax_valid(self):
+        text = _readme_text()
+        bash_blocks = re.findall(r"```bash\n(.*?)\n```", text, re.DOTALL)
+
+        self.assertTrue(bash_blocks)
+        for block in bash_blocks:
+            result = subprocess.run(
+                ["bash", "-n"],
+                input=block,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes the persistent deployment README guidance so the bearer-token prose uses the same `TOKEN` variable as the curl example and avoids malformed inline quoting.

Closes #44.

## Key Changes
- Updates the reverse proxy auth guidance in `README.md` to use `Authorization: Bearer $TOKEN`.
- Adds README regression coverage for the deployment token placeholder and fenced bash syntax in `tests/test_readme.py`.

## Validation
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest tests.test_readme -v`
- `env UV_CACHE_DIR=/tmp/hermes-a2a-uv-cache uv run python -m unittest discover -s tests -v`
- `git diff --check`